### PR TITLE
Stacked bar: add a grey background rectangle

### DIFF
--- a/src/lib/components/particles/stacked-bar/index.jsx
+++ b/src/lib/components/particles/stacked-bar/index.jsx
@@ -3,7 +3,7 @@ import { isDarkColor } from '$shared/colors'
 import defaultStyles from './style.module.css'
 import { mergeStyles } from '$styles/helpers/mergeStyles'
 
-export function StackedBar({ stack, width, height, createSVG = true, styles }) {
+export function StackedBar({ stack, width, height, showBgRect, createSVG = true, styles }) {
   const rectElements = useRef([])
   const textElements = useRef([])
   const [hideLabels, setHideLabels] = useState(true)
@@ -63,9 +63,13 @@ export function StackedBar({ stack, width, height, createSVG = true, styles }) {
         </text>
       </g>
     )
+
     totalWidth += itemWidth
     return value
   })
+
+  const bgRect = (<g className="background-fill"><rect x="0" y="0" height={height} width={width} className={styles.bgRectFill} /></g>)
+  
 
   if (createSVG) {
     return (
@@ -76,6 +80,7 @@ export function StackedBar({ stack, width, height, createSVG = true, styles }) {
         viewBox={`0 0 ${width} ${height}`}
         xmlns="http://www.w3.org/2000/svg"
       >
+        {showBgRect && bgRect}
         {content}
       </svg>
     )

--- a/src/lib/components/particles/stacked-bar/stacked-bar.stories.jsx
+++ b/src/lib/components/particles/stacked-bar/stacked-bar.stories.jsx
@@ -11,8 +11,8 @@ export const UsingHexColours = {
   args: {
     stack: [
       {
-        label: '120',
-        fraction: 0.6,
+        label: '40',
+        fraction: 0.2,
         fill: '#FF0000',
       },
       {
@@ -23,11 +23,12 @@ export const UsingHexColours = {
       {
         label: '40',
         fraction: 0.2,
-        fill: '#CCC',
+        fill: '#E05E00',
       },
     ],
     width: 358,
     height: 32,
+    showBgRect: true,
   },
   render: (args) => <StackedBar {...args} />,
 }
@@ -53,6 +54,7 @@ export const UsingAbbreviations = {
     ],
     width: 358,
     height: 32,
+    showBgRect: false,
   },
   render: (args) => <StackedBar {...args} />,
 }
@@ -78,6 +80,7 @@ export const Compact = {
     ],
     width: 200,
     height: 20,
+    showBgRect: true,
   },
   render: (args) => <StackedBar {...args} />,
 }

--- a/src/lib/components/particles/stacked-bar/style.module.css
+++ b/src/lib/components/particles/stacked-bar/style.module.css
@@ -7,3 +7,7 @@
   font-size: var(--sans-xsmall);
   line-height: var(--sans-line-height);
 }
+
+.bgRectFill {
+  fill: var(--news-grey-05);
+}


### PR DESCRIPTION
This grey background rectangle shows the shape of the bar when the actual rects don't take up the full space. For eg, when only partial election results are available: 

<img width="798" alt="Screenshot 2024-03-13 at 14 19 06" src="https://github.com/guardian/interactive-component-library/assets/10324129/fc07d08d-d22c-42fe-acfd-911dddcb03dc">

And using the Eu election as an example:
<img width="985" alt="Screenshot 2024-03-13 at 14 29 25" src="https://github.com/guardian/interactive-component-library/assets/10324129/c4d13ddf-9a0d-48e0-bd06-0ce1466e152a">

With dark mode:
<img width="985" alt="Screenshot 2024-03-13 at 14 30 03" src="https://github.com/guardian/interactive-component-library/assets/10324129/9b13e006-00e4-4776-8437-c8899a576987">
