### PR TITLE
Table Molecule: option to hide header

### DIFF
--- a/src/lib/components/molecules/table/index.jsx
+++ b/src/lib/components/molecules/table/index.jsx
@@ -4,7 +4,7 @@ import { Chevron } from '$particles/chevron'
 import defaultStyles from './style.module.scss'
 import { mergeStyles } from '$styles/helpers/mergeStyles'
 
-export function Table({ columns, data, hideHeader, styles }) {
+export function Table({ columns, data, hideHeader=false, styles }) {
   const [sortState, setSortState] = useState(() => {
     const columnIndex = columns.findIndex((column) => {
       if ('sort' in column) {

--- a/src/lib/components/molecules/table/index.jsx
+++ b/src/lib/components/molecules/table/index.jsx
@@ -1,10 +1,10 @@
 import { useState } from 'preact/hooks'
 import { useTable } from './useTable'
 import { Chevron } from '$particles/chevron'
-import defaultStyles from './style.module.css'
+import defaultStyles from './style.module.scss'
 import { mergeStyles } from '$styles/helpers/mergeStyles'
 
-export function Table({ columns, data, styles }) {
+export function Table({ columns, data, hideHeader, styles }) {
   const [sortState, setSortState] = useState(() => {
     const columnIndex = columns.findIndex((column) => {
       if ('sort' in column) {
@@ -34,7 +34,7 @@ export function Table({ columns, data, styles }) {
 
   return (
     <table className={styles.table}>
-      <thead>
+      <thead className={hideHeader && styles.hideHeader}>
         <tr>
           {table.columns.map((column, index) => (
             <th key={column.id} className={mergeStyles(styles.headerCell, column.styles?.headerCell)}>
@@ -48,7 +48,7 @@ export function Table({ columns, data, styles }) {
           ))}
         </tr>
       </thead>
-      <tbody>
+      <tbody className={hideHeader && styles.hideHeaderNoBorder}>
         {table.rows.map((row) => {
           return (
             <tr key={row.id} className={styles.bodyRow}>

--- a/src/lib/components/molecules/table/style.module.scss
+++ b/src/lib/components/molecules/table/style.module.scss
@@ -7,6 +7,21 @@
   text-align: left;
 }
 
+.hideHeader {
+  visibility: hidden;
+  th {
+    padding-top: 0;
+    padding-bottom: 0;
+    line-height: 0;
+  }
+}
+
+.hideHeaderNoBorder {
+  tr:first-of-type {
+    border-top: none;
+  }
+}
+
 .headerCell {
   font-weight: 700;
   white-space: nowrap;

--- a/src/lib/components/molecules/table/table.stories.jsx
+++ b/src/lib/components/molecules/table/table.stories.jsx
@@ -36,6 +36,7 @@ export const Default = {
         lastName: 'Smith',
       },
     ],
+    hideHeader: false,
   },
 }
 
@@ -63,6 +64,7 @@ export const Sortable = {
         lastName: 'Smith',
       },
     ],
+    hideHeader: false,
   },
 }
 
@@ -139,5 +141,6 @@ export const PartyResults = {
   args: {
     columns,
     data,
+    hideHeader: false,
   },
 }

--- a/src/lib/components/molecules/table/table.stories.jsx
+++ b/src/lib/components/molecules/table/table.stories.jsx
@@ -64,7 +64,6 @@ export const Sortable = {
         lastName: 'Smith',
       },
     ],
-    hideHeader: false,
   },
 }
 
@@ -141,6 +140,5 @@ export const PartyResults = {
   args: {
     columns,
     data,
-    hideHeader: false,
   },
 }


### PR DESCRIPTION
In some designs, we hide the header of a table. This adds an option so the user can choose not to show the header

But we don't want to remove the header entirely - ie: by using `display: none;` - because column widths are calculated by the table header cells. 

Instead we apply a class that uses `visibility: hidden;` and various other CSS properties to keep the effects of the table header but to hide it from view. 

QUESTION: should i add an option to make the first row bold? or should this be achievable thru the style prop? 

WITH HEADER 
<img width="824" alt="Screenshot 2024-04-03 at 12 07 54" src="https://github.com/guardian/interactive-component-library/assets/10324129/f377f734-3b47-46fa-8e48-707aac54c1d7">


WITHOUT HEADER 
<img width="824" alt="Screenshot 2024-04-03 at 12 07 49" src="https://github.com/guardian/interactive-component-library/assets/10324129/8a658d10-254c-4d4c-abff-34f0f4c107c9">


- works less well for sortable tables - but by definition these should have a header - otherwise they are not sortable 