### PR TITLE
fix second react import

### DIFF
--- a/src/lib/components/organisms/ticker/ticker.stories.jsx
+++ b/src/lib/components/organisms/ticker/ticker.stories.jsx
@@ -1,9 +1,8 @@
 import { Ticker } from '.'
 import { Container } from '$particles'
 import { PageSection, ResultSummary } from '$molecules'
-import { useRef } from 'preact/hooks'
+import { useRef, useEffect } from 'preact/hooks'
 import styles from './stories.module.scss'
-import { useEffect } from 'react'
 
 const now = Date.now()
 const minuteInMilliseconds = 60000

--- a/src/lib/components/particles/gradient-icon/index.jsx
+++ b/src/lib/components/particles/gradient-icon/index.jsx
@@ -1,6 +1,6 @@
 import defaultStyles from "./style.module.css"
 import { mergeStyles } from "$styles/helpers/mergeStyles"
-import { useId } from 'preact/compat'
+import { useId } from 'preact/hooks'
 
 export const GradientIcon = ({
   previous,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
