### PR TITLE
Topline Result - add a style prop to stories

### DIFF
--- a/src/lib/components/molecules/topline-result/topline-result.stories.jsx
+++ b/src/lib/components/molecules/topline-result/topline-result.stories.jsx
@@ -1,5 +1,6 @@
 import { action } from '@storybook/addon-actions'
 import { ToplineResult } from '.'
+import styles from './topline-result.stories.module.scss'
 
 export default {
   title: 'Molecules/ToplineResult',
@@ -38,6 +39,10 @@ export const Row = {
     mainNumber: 300,
     secondaryNumber: 120,
     displayRow: true,
+    styles: {
+      toplineResult: styles.rightAlignToplineResult,
+      name: styles.rightAlignName
+    },
   },
   render: (args) => <ToplineResult {...args} />,
 }

--- a/src/lib/components/molecules/topline-result/topline-result.stories.module.scss
+++ b/src/lib/components/molecules/topline-result/topline-result.stories.module.scss
@@ -1,0 +1,17 @@
+  .rightAlignToplineResult {
+    display: flex;
+    flex-direction: column;
+    justify-content: end;
+
+    > div {
+        align-self: flex-end;
+    }
+  }
+
+  .rightAlignName {
+    &:before {
+        margin-right: 0;
+        margin-left: auto;
+    }
+  }
+  


### PR DESCRIPTION
Small PR just adding to a story. 

Documents how to right-align the topline result component so it can look like this: 

<img width="696" alt="Screenshot 2024-04-04 at 16 47 05" src="https://github.com/guardian/interactive-component-library/assets/10324129/9148f586-7f89-480a-8cbf-36ab8802d254">

