### PR TITLE
set map colour defaults to null and add style file for composition border

### DIFF
--- a/src/lib/components/molecules/map/layers/CompositionBorders.jsx
+++ b/src/lib/components/molecules/map/layers/CompositionBorders.jsx
@@ -1,8 +1,12 @@
 import { useContext } from 'preact/hooks'
 import { MapContext } from '../context/MapContext'
+import defaultStyles from './compositionBorders.module.scss'
+import { mergeStyles } from '$styles/helpers/mergeStyles'
 
-export function CompositionBorders() {
+export function CompositionBorders({ styles }) {
   const { projection } = useContext(MapContext)
+  
+  styles = mergeStyles(defaultStyles, styles)
 
   // const ctx = drawingContext
   // if (drawingContext) {
@@ -14,5 +18,5 @@ export function CompositionBorders() {
   //   return
   // }
 
-  return <path stroke="#dcdcdc" fill="none" d={projection.getCompositionBorders()} />
+  return <path className={styles.path} d={projection.getCompositionBorders()} />
 }

--- a/src/lib/components/molecules/map/layers/Line.jsx
+++ b/src/lib/components/molecules/map/layers/Line.jsx
@@ -2,7 +2,7 @@ import { useContext, useEffect } from 'preact/hooks'
 import { MapContext } from '../context/MapContext'
 import { dynamicPropValue } from '../helpers/dynamicPropValue'
 
-export function Line({ features, stroke = '#FFF', strokeWidth = 1, styles }) {
+export function Line({ features, stroke = null, strokeWidth = 1, styles }) {
   const context = useContext(MapContext)
 
   const draw = (ctx, path) => {

--- a/src/lib/components/molecules/map/layers/Point.jsx
+++ b/src/lib/components/molecules/map/layers/Point.jsx
@@ -2,7 +2,7 @@ import { useContext } from 'preact/hooks'
 import { MapContext } from '../context/MapContext'
 import { dynamicPropValue } from '../helpers/dynamicPropValue'
 
-export function Point({ features, radius = 4, fill = '#FF0000', stroke = 'none', strokeWidth = 1, styles }) {
+export function Point({ features, radius = 4, fill = null, stroke = null, strokeWidth = 1, styles }) {
   const context = useContext(MapContext)
 
   return (

--- a/src/lib/components/molecules/map/layers/Polygon.jsx
+++ b/src/lib/components/molecules/map/layers/Polygon.jsx
@@ -2,7 +2,7 @@ import { useContext } from 'preact/hooks'
 import { MapContext } from '../context/MapContext'
 import { dynamicPropValue } from '../helpers/dynamicPropValue'
 
-export function Polygon({ features, fill = '#DCDCDC', stroke = 'none', strokeWidth = 1, styles }) {
+export function Polygon({ features, fill = null, stroke = null, strokeWidth = 1, styles }) {
   const context = useContext(MapContext)
   // const { drawToCanvas } = context.config
 

--- a/src/lib/components/molecules/map/layers/compositionBorders.module.scss
+++ b/src/lib/components/molecules/map/layers/compositionBorders.module.scss
@@ -1,0 +1,4 @@
+.path {
+  stroke: var(--secondary-line-color);
+  fill: none;
+}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
