### PR TITLE
Add zero line to changebar

### DIFF
--- a/src/lib/components/particles/change-bar/index.jsx
+++ b/src/lib/components/particles/change-bar/index.jsx
@@ -20,10 +20,14 @@ export function ChangeBar({ fraction, positive, party, width, height, styles }) 
   ` height: ${height}; width: ${barwidth}px; ${positive ? `left: ${posleft}` : `left: ${negleft}`}`
   let thisColor = ` bg-color--${party}`
 
+  let zeroStyles = ` height: ${height}; width: 1px; left: 50%; transform: scaleY(2);`
+
   styles = mergeStyles({ ...defaultStyles }, styles)
 
 
   return <div className={styles.wrapper} style={`width: ${width}px`}>
     <div className={styles.bar.concat(thisColor)} style={thisStyles}></div>
+    <div className={styles.zero} style={zeroStyles}></div>
+
     </div>
 }

--- a/src/lib/components/particles/change-bar/index.jsx
+++ b/src/lib/components/particles/change-bar/index.jsx
@@ -20,7 +20,7 @@ export function ChangeBar({ fraction, positive, party, width, height, styles }) 
   ` height: ${height}; width: ${barwidth}px; ${positive ? `left: ${posleft}` : `left: ${negleft}`}`
   let thisColor = ` bg-color--${party}`
 
-  let zeroStyles = ` height: ${height}; width: 1px; left: 50%; transform: scaleY(2);`
+  let zeroStyles = ` height: ${height};`
 
   styles = mergeStyles({ ...defaultStyles }, styles)
 
@@ -28,6 +28,5 @@ export function ChangeBar({ fraction, positive, party, width, height, styles }) 
   return <div className={styles.wrapper} style={`width: ${width}px`}>
     <div className={styles.bar.concat(thisColor)} style={thisStyles}></div>
     <div className={styles.zero} style={zeroStyles}></div>
-
     </div>
 }

--- a/src/lib/components/particles/change-bar/style.module.scss
+++ b/src/lib/components/particles/change-bar/style.module.scss
@@ -1,6 +1,6 @@
 .wrapper {
-	// width: 100%;
-	// background-color: grey;
+	overflow: visible;
+	position: relative;
 }
 
 .bar {
@@ -8,3 +8,8 @@
 	height: 1em;
   }
   
+.zero {
+	background-color: var(--primary-text-color);
+	position: absolute;
+	top: 0px;
+}

--- a/src/lib/components/particles/change-bar/style.module.scss
+++ b/src/lib/components/particles/change-bar/style.module.scss
@@ -12,4 +12,7 @@
 	background-color: var(--primary-text-color);
 	position: absolute;
 	top: 0px;
+	transform: scaleY(2);
+	width: 1px;
+	left: 50%;
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
