### PR TITLE
set default labels to inline

### DIFF
--- a/src/lib/components/particles/stacked-bar/index.jsx
+++ b/src/lib/components/particles/stacked-bar/index.jsx
@@ -86,7 +86,7 @@ export function StackedBar({
       return labelConfig
     })
     
-    return preventOverlap(labels, 0, 20, 'x')
+    return preventOverlap(labels, 0, 20, 'x', false)
   }, [stack, height, width])
 
 

--- a/src/lib/shared/helpers/labelsUtil.js
+++ b/src/lib/shared/helpers/labelsUtil.js
@@ -1,4 +1,4 @@
-export function preventOverlap(labelPositions, iteration = 0, labelSize = 12, coordinate ='y') {
+export function preventOverlap(labelPositions, iteration = 0, labelSize = 12, coordinate ='y', moveBothLabels = true) {
   const maxIterations = 10
   let totalOverlap = 0
 
@@ -12,14 +12,15 @@ export function preventOverlap(labelPositions, iteration = 0, labelSize = 12, co
       continue
     }
 
-    previousElement[coordinate] -= overlap / 2
-    element[coordinate] += overlap / 2
-
-    totalOverlap += overlap
-  }
+    if (moveBothLabels) {
+      previousElement[coordinate] -= overlap / 2;
+      element[coordinate] += overlap / 2;
+    } else {
+      previousElement[coordinate] -= overlap;
+    }
 
   if (totalOverlap > 0 && iteration < maxIterations) {
-    return preventOverlap(labelPositions, iteration + 1, labelSize, coordinate)
+    return preventOverlap(labelPositions, iteration + 1, labelSize, coordinate, moveBothLabels)
   }
 
   return labelPositions
@@ -29,12 +30,12 @@ export function uniqueBy(array, key) {
   return [...array.reduce((map, d) => map.set(d[key], d), new Map()).values()]
 }
 
-export function positionLabels(labels, labelSize=12, coordinate = 'y') {
+  export function positionLabels(labels, labelSize = 12, coordinate = 'y', moveBothLabels = true) {
   labels = uniqueBy(labels, 'value')
   // sort by coordinate-position
   labels.sort((a, b) => a[coordinate] - b[coordinate])
   
-  return preventOverlap(labels, 0, labelSize, coordinate)
+  return preventOverlap(labels, 0, labelSize, coordinate, moveBothLabels)
 }
 
 // same as this one https://gist.github.com/vectorsize/7031902


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
