### PR TITLE
Set min height based on header content

### DIFF
--- a/src/lib/components/molecules/page-section/index.jsx
+++ b/src/lib/components/molecules/page-section/index.jsx
@@ -1,4 +1,5 @@
 import { forwardRef } from 'preact/compat'
+import { useLayoutEffect, useRef, useState } from 'preact/hooks'
 import { mergeStyles } from '$styles/helpers/mergeStyles'
 import defaultStyles from './style.module.scss'
 
@@ -6,13 +7,21 @@ export const PageSection = forwardRef(
   ({ children, styles, borderTop = false, backgroundColor = 'transparent' }, ref) => {
     styles = mergeStyles({ ...defaultStyles }, styles)
 
+    const [minHeight, setMinHeight] = useState('auto')
+    const headerRef = useRef()
+
+    useLayoutEffect(() => {
+      const headerElement = headerRef.current
+      setMinHeight(headerElement.offsetHeight)
+    }, [children])
+
     return (
       <section
         ref={ref}
         className={[styles.section, borderTop && styles.borderTop].join(' ')}
-        style={{ '--background-color': backgroundColor }}
+        style={{ '--background-color': backgroundColor, minHeight }}
       >
-        <div className={styles.header}>{children.header}</div>
+        <div className={styles.header} ref={headerRef}>{children.header}</div>
         <div className={styles.content}>{children.content}</div>
       </section>
     )

--- a/src/lib/components/molecules/page-section/page-section.stories.jsx
+++ b/src/lib/components/molecules/page-section/page-section.stories.jsx
@@ -66,3 +66,37 @@ export const BackgroundColor = {
     borderTop: true,
   },
 }
+
+export const SectionWithLongHeaderContent = {
+  render: (args) => {
+    return (
+      <>
+        <PageSection {...args}>
+          {{
+            header: (
+              <div>
+                <h2>Section one</h2>
+                <p>
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris fringilla, libero vel fermentum
+                  dapibus, neque eros interdum magna, at cursus enim justo nec elit. Orci varius natoque penatibus et
+                  magnis dis parturient montes, nascetur ridiculus mus. Maecenas accumsan sem lacinia turpis
+                  ullamcorper, imperdiet dictum justo euismod. Quisque justo sem, porta non dictum eget, pharetra a
+                  erat. Quisque sollicitudin aliquet sem, sed feugiat tortor luctus id. Maecenas tincidunt sapien sit
+                  amet urna varius finibus. Nunc finibus arcu ac elementum gravida. Aenean blandit ut arcu eget ornare.
+                  Curabitur in malesuada ipsum, ut aliquet est.
+                </p>
+              </div>
+            ),
+            content: <p className={styles.content}>Section content</p>,
+          }}
+        </PageSection>
+        <PageSection borderTop={true}>
+          {{
+            header: <h2>Section two</h2>,
+            content: <p className={styles.content}>Section content</p>,
+          }}
+        </PageSection>
+      </>
+    )
+  },
+}


### PR DESCRIPTION
Fixes for: https://trello.com/c/94jEbrB1/263-section-component-if-we-edited-the-section-blurbs-to-be-bigger-they-would-spill-over-vertically-eg-regional-mayors