### PR TITLE
Dropdown group headings fix

### DIFF
--- a/src/lib/components/molecules/dropdown/index.jsx
+++ b/src/lib/components/molecules/dropdown/index.jsx
@@ -64,7 +64,7 @@ export function Dropdown({ title, hint, options, onSelect, collapseOnSelect = fa
 function OptionGroup({ title, options, selectedIndex, onOptionClick }) {
   return (
     <>
-      {title && <p className={styles.groupHeader}>{title}</p>}
+      {title && <span className={styles.groupHeader}>{title}</span>}
       {options.map((option) => {
         return (
           <button key={option.title} className={styles.option} onClick={() => onOptionClick(option, option.index)}>


### PR DESCRIPTION
<img width="233" alt="image" src="https://github.com/guardian/interactive-component-library/assets/4135753/0e9a398d-fb2d-4ff3-b32f-bfef50b82eea">
It fixes the color for group headings on dark mode