### PR TITLE
Remove use of toSorted function

### DIFF
--- a/src/lib/components/molecules/table/table.stories.jsx
+++ b/src/lib/components/molecules/table/table.stories.jsx
@@ -1,14 +1,14 @@
-import { Table } from '.'
-import { LegendItem } from '$particles/legend-item'
-import Markdown from 'markdown-to-jsx'
-import styles from './table.stories.module.css'
+import { Table } from "."
+import { LegendItem } from "$particles/legend-item"
+import Markdown from "markdown-to-jsx"
+import styles from "./table.stories.module.css"
 
 const meta = {
-  title: 'Molecules/Table',
+  title: "Molecules/Table",
   component: Table,
   parameters: {
     viewport: {
-      defaultViewport: 'desktop',
+      defaultViewport: "desktop",
     },
   },
 }
@@ -19,22 +19,22 @@ export const Default = {
   args: {
     columns: [
       {
-        header: 'First name',
-        accessor: 'firstName',
+        header: "First name",
+        accessor: "firstName",
       },
       {
-        header: 'Last name',
-        accessor: 'lastName',
+        header: "Last name",
+        accessor: "lastName",
       },
     ],
     data: [
       {
-        firstName: 'Margaret',
-        lastName: 'Jones',
+        firstName: "Margaret",
+        lastName: "Jones",
       },
       {
-        firstName: 'Jake',
-        lastName: 'Smith',
+        firstName: "Jake",
+        lastName: "Smith",
       },
     ],
     hideHeader: false,
@@ -45,24 +45,27 @@ export const Sortable = {
   args: {
     columns: [
       {
-        header: 'First name',
-        accessor: 'firstName',
+        header: "First name",
+        accessor: "firstName",
         sortable: true,
+        sort: {
+          ascending: false,
+        },
       },
       {
-        header: 'Last name',
-        accessor: 'lastName',
+        header: "Last name",
+        accessor: "lastName",
         sortable: true,
       },
     ],
     data: [
       {
-        firstName: 'Margaret',
-        lastName: 'Jones',
+        firstName: "Margaret",
+        lastName: "Jones",
       },
       {
-        firstName: 'Jake',
-        lastName: 'Smith',
+        firstName: "Jake",
+        lastName: "Smith",
       },
     ],
   },
@@ -72,18 +75,18 @@ export const PartyResults = {
   args: {
     columns: [
       {
-        header: 'Party',
-        accessor: 'partyName',
+        header: "Party",
+        accessor: "partyName",
         cell: (d) => <LegendItem text={d.partyName} styles={{ dot: `bg-color--${d.abbreviation}` }} />,
         styles: {
-          headerCell: styles['w-2/5'],
+          headerCell: styles["w-2/5"],
         },
       },
       {
-        header: 'Seats',
-        accessor: 'totalSeats',
+        header: "Seats",
+        accessor: "totalSeats",
         styles: {
-          headerCell: [styles['w-1/5'], styles.rightAlign].join(' '),
+          headerCell: [styles["w-1/5"], styles.rightAlign].join(" "),
           bodyCell: styles.rightAlign,
         },
         sort: {
@@ -91,47 +94,47 @@ export const PartyResults = {
         },
       },
       {
-        header: 'Gains',
-        accessor: 'gains',
+        header: "Gains",
+        accessor: "gains",
         styles: {
-          headerCell: [styles['w-1/5'], styles.rightAlign].join(' '),
+          headerCell: [styles["w-1/5"], styles.rightAlign].join(" "),
           bodyCell: styles.rightAlign,
         },
       },
       {
-        header: 'Losses',
-        accessor: 'losses',
+        header: "Losses",
+        accessor: "losses",
         styles: {
-          headerCell: [styles['w-1/5'], styles.rightAlign].join(' '),
+          headerCell: [styles["w-1/5"], styles.rightAlign].join(" "),
           bodyCell: styles.rightAlign,
         },
       },
     ],
     data: [
       {
-        partyName: 'Conservatives',
-        abbreviation: 'con',
+        partyName: "Conservatives",
+        abbreviation: "con",
         totalSeats: 38,
         gains: 0,
         losses: 47,
       },
       {
-        partyName: 'Labour',
-        abbreviation: 'lab',
+        partyName: "Labour",
+        abbreviation: "lab",
         totalSeats: 41,
         gains: 20,
         losses: 2,
       },
       {
-        partyName: 'Liberal Democrats',
-        abbreviation: 'libdem',
+        partyName: "Liberal Democrats",
+        abbreviation: "libdem",
         totalSeats: 19,
         gains: 12,
         losses: 4,
       },
       {
-        partyName: 'Green',
-        abbreviation: 'green',
+        partyName: "Green",
+        abbreviation: "green",
         totalSeats: 6,
         gains: 2,
         losses: 1,
@@ -144,56 +147,56 @@ export const ColumnDefinitions = {
   args: {
     columns: [
       {
-        header: 'Property',
-        accessor: 'property',
+        header: "Property",
+        accessor: "property",
         cell: (d) => <SourceCodeCell source={d.property} />,
         styles: {
-          headerCell: styles['w-1/5'],
+          headerCell: styles["w-1/5"],
         },
       },
       {
-        header: 'Description',
-        accessor: 'description',
+        header: "Description",
+        accessor: "description",
         cell: (d) => <Markdown>{d.description}</Markdown>,
         styles: {
-          headerCell: styles['w-3/5'],
+          headerCell: styles["w-3/5"],
         },
       },
       {
-        header: 'Default value',
-        accessor: 'default',
+        header: "Default value",
+        accessor: "default",
         cell: (d) => <Markdown>{d.default}</Markdown>,
         styles: {
-          headerCell: styles['w-1/5'],
+          headerCell: styles["w-1/5"],
         },
       },
     ],
     data: [
       {
-        property: 'id',
-        description: 'Unique identifier for this column',
-        default: 'Defaults to value of `header` prop',
+        property: "id",
+        description: "Unique identifier for this column",
+        default: "Defaults to value of `header` prop",
       },
       {
-        property: 'header',
-        description: 'The column header name. It will not show if `hideHeader` prop on Table equals `true`',
-        default: '-',
+        property: "header",
+        description: "The column header name. It will not show if `hideHeader` prop on Table equals `true`",
+        default: "-",
       },
       {
-        property: 'accessor',
-        description: 'The key for accessing the value of each object in the `data` array',
-        default: '-',
+        property: "accessor",
+        description: "The key for accessing the value of each object in the `data` array",
+        default: "-",
       },
       {
-        property: 'cell',
-        description: 'Optional function that receives a datum and returns a table cell for the current row',
-        default: '-',
+        property: "cell",
+        description: "Optional function that receives a datum and returns a table cell for the current row",
+        default: "-",
       },
       {
-        property: 'sort',
+        property: "sort",
         description:
-          'If property exists then the table will be sortable by the values in this column <br/><br/>Valid values:<br/><ul><li>`{ ascending: true }`</li><li>`{ ascending: false }`</li></ul>',
-        default: '-',
+          "If property exists then the table will be sortable by the values in this column <br/><br/>Valid values:<br/><ul><li>`{ ascending: true }`</li><li>`{ ascending: false }`</li></ul>",
+        default: "-",
       },
     ],
   },

--- a/src/lib/components/molecules/table/useTable.jsx
+++ b/src/lib/components/molecules/table/useTable.jsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'preact/hooks'
+import { useMemo } from "preact/hooks"
 
 const sortAscending = (accessor) => {
   return (a, b) => {
@@ -25,9 +25,11 @@ export function useTable({ columns, data, sortState }) {
     if (sortState.columnIndex < 0) {
       return data
     }
+    const dataCopy = new Array(...data)
     const column = columns[sortState.columnIndex]
     const sortFunction = sortState.ascending ? sortAscending(column.accessor) : sortDescending(column.accessor)
-    return data.toSorted(sortFunction)
+    dataCopy.sort(sortFunction)
+    return dataCopy
   }, [columns, data, sortState])
 
   const columnModels = useMemo(() => {


### PR DESCRIPTION
Remove use of `Array.prototype.toSorted()` function because it is not supported by older browsers