### PR TITLE
Ticker Bug: change hidebutton function to fix mobile bug

### DIFF
--- a/src/lib/components/organisms/ticker/index.jsx
+++ b/src/lib/components/organisms/ticker/index.jsx
@@ -1,9 +1,9 @@
-import { toChildArray } from 'preact'
-import { useState, useRef, useLayoutEffect, useMemo } from 'preact/hooks'
-import { useWindowSize } from '$shared/hooks/useWindowSize'
-import { Gradient } from './gradient'
-import { ArrowButton, Button } from '$particles'
-import styles from './style.module.scss'
+import { toChildArray } from "preact"
+import { useState, useRef, useLayoutEffect, useMemo } from "preact/hooks"
+import { useWindowSize } from "$shared/hooks/useWindowSize"
+import { Gradient } from "./gradient"
+import { ArrowButton, Button } from "$particles"
+import styles from "./style.module.scss"
 
 export function Ticker({ maxItems = 20, onStateChange, children }) {
   const [pageIndex, setPageIndex] = useState(0)
@@ -39,10 +39,8 @@ export function Ticker({ maxItems = 20, onStateChange, children }) {
   useLayoutEffect(() => {
     const tickerItemsContainer = tickerItemsRef.current
 
-    const hideButtons =
-      windowSize.width >= 480
-        ? tickerScrollRef.current.scrollWidth <= tickerItemsContainer.clientWidth
-        : tickerScrollRef.current.scrollHeight <= tickerItemsContainer.clientHeight
+    const hideButtons = windowSize.width >= 480 ? tickerScrollRef.current.scrollWidth <= tickerItemsContainer.clientWidth : childArray.length < 3
+
     setHideButtons(hideButtons)
   }, [windowSize, setHideButtons])
 
@@ -55,12 +53,7 @@ export function Ticker({ maxItems = 20, onStateChange, children }) {
   }
 
   return (
-    <div
-      ref={tickerRef}
-      className={styles.ticker}
-      style={`--ticker-offset: ${offsetWidth}px;`}
-      data-expanded={expanded}
-    >
+    <div ref={tickerRef} className={styles.ticker} style={`--ticker-offset: ${offsetWidth}px;`} data-expanded={expanded}>
       <div ref={tickerItemsRef} className={styles.tickerItems}>
         <div ref={tickerScrollRef} className={styles.tickerScroll}>
           {childArray.map((child, index) => (
@@ -70,7 +63,7 @@ export function Ticker({ maxItems = 20, onStateChange, children }) {
           ))}
         </div>
       </div>
-      <div ref={controlsRef} className={styles.controls} style={hideButtons && { display: 'none' }}>
+      <div ref={controlsRef} className={styles.controls} style={hideButtons && { display: "none" }}>
         <div className={styles.gradient}>
           <Gradient />
         </div>
@@ -80,7 +73,7 @@ export function Ticker({ maxItems = 20, onStateChange, children }) {
         </div>
         <div className={styles.button}>
           <Button type="regular" styles={{ buttonInner: styles.buttonInner }} onClick={toggleExpandedState}>
-            {expanded ? 'Show fewer' : `Show ${maxItems} most recent`}
+            {expanded ? "Show fewer" : `Show ${maxItems} most recent`}
           </Button>
         </div>
       </div>


### PR DESCRIPTION
On mobile iOS (safari and app) the button control panel for the ticker got hidden too easily - anytime the panel was expanded.

This changes the check at mobile width to prevent this happening. Only when there two or fewer items in the ticker will the buttons disappear. The height check was producing the wrong effect and got triggered too easily.

BUG:  - show fewer button hidden at bottom 
![image](https://github.com/guardian/interactive-component-library/assets/10324129/95e4344b-08ae-46aa-856b-f30a0a4715dd)


WORKING: 

https://github.com/guardian/interactive-component-library/assets/10324129/9e6d8d2c-4ce1-4798-8f62-4ca62eb85c83




NB: lots of linting changes here 