### PR TITLE
pass styles prop from coalitions to stacked bars children

### DIFF
--- a/src/lib/components/organisms/coalitions-tracker/index.jsx
+++ b/src/lib/components/organisms/coalitions-tracker/index.jsx
@@ -66,7 +66,7 @@ export function CoalitionsTracker({
         <p className={styles.description} style={{ maxWidth: thresholdLeft <= 620 ? thresholdLeft - 8 : 620 }}>
           {list.description}
         </p>
-        <StackedBar labelOverlapConfig={labelOverlapConfig} labelType={LabelType.hanging} stack={list.stack} width={list.width} height={barChartHeight} createSVG={true} />
+        <StackedBar labelOverlapConfig={labelOverlapConfig} labelType={LabelType.hanging} stack={list.stack} width={list.width} height={barChartHeight} createSVG={true} styles={styles} />
       </div>
     )
   }


### PR DESCRIPTION
without this change it's impossible to override the styles of the stacked bars created by the coalitions bar. Not everything can be targeted with nesting.