### PR TITLE
Waffle component: add onclick event

### DIFF
--- a/src/lib/components/particles/waffle/index.jsx
+++ b/src/lib/components/particles/waffle/index.jsx
@@ -1,17 +1,16 @@
 import defaultStyles from "./style.module.css"
 import { mergeStyles } from "$styles/helpers/mergeStyles"
-import { useContainerSize } from '$shared/hooks/useContainerSize'
-import { useRef } from 'preact/hooks'
+import { useContainerSize } from "$shared/hooks/useContainerSize"
+import { useRef } from "preact/hooks"
 
 export const WaffleType = {
-  circle: 'circle',
-  square: 'square',
+  circle: "circle",
+  square: "square",
 }
 
-const WaffleUnit = ({ type, attributes }) => type === WaffleType.square ? <rect {...attributes} /> : <circle {...attributes} />
+const WaffleUnit = ({ type, attributes }) => (type === WaffleType.square ? <rect {...attributes} /> : <circle {...attributes} />)
 
-export const Waffle = ({ units, numberOfRows, type = WaffleType.circle, idAccessor, onMouseOver, styles }) => {
-
+export const Waffle = ({ units, numberOfRows, type = WaffleType.circle, idAccessor, onMouseOver = () => {}, onClick = () => {}, styles }) => {
   const containerRef = useRef()
   const containerSize = useContainerSize(containerRef)
   const width = containerSize ? containerSize.width : 0
@@ -20,44 +19,44 @@ export const Waffle = ({ units, numberOfRows, type = WaffleType.circle, idAccess
   const unitWidth = width / columns
   const unitHeight = unitWidth
   const height = numberOfRows * unitHeight
-  
+
   styles = mergeStyles(defaultStyles, styles)
 
   return (
     <div ref={containerRef} className={styles.container}>
-      { containerSize &&
+      {containerSize && (
         <svg viewBox={`0 0 ${width} ${height}`} class={styles.svg}>
           <g>
-            {
-              units.map((unit, j) => {
-                let attributes
-                
-                if (type === WaffleType.square) {
-                  attributes = {
-                    id: unit[idAccessor] || `w-${j}`,
-                    onMouseOver: e => onMouseOver(unit, e),
-                    class: `${styles.unit} ${unit.class}`,
-                    height: unitHeight,
-                    width: unitWidth,
-                    x: unitWidth * Math.floor(j / numberOfRows),
-                    y: unitHeight * (j % numberOfRows)
-                  }
-                } else {
-                  attributes = {
-                    id: unit[idAccessor] || `w-${j}`,
-                    onMouseOver: e => onMouseOver(unit, e),
-                    class: `${styles.unit} ${unit.class}`,
-                    r: unitWidth / 2,
-                    transform: `translate(${unitWidth * Math.floor(j / numberOfRows) + unitWidth / 2}, ${unitHeight * (j % numberOfRows) + unitHeight / 2 })`
-                  }
-                }
+            {units.map((unit, j) => {
+              let attributes
 
-                return <WaffleUnit key={`wu-${j}`} type={type} attributes={attributes} />
-              })
-            }
+              if (type === WaffleType.square) {
+                attributes = {
+                  id: unit[idAccessor] || `w-${j}`,
+                  onMouseOver: (e) => onMouseOver(unit, e),
+                  onClick: (e) => onClick(unit, e),
+                  class: `${styles.unit} ${unit.class}`,
+                  height: unitHeight,
+                  width: unitWidth,
+                  x: unitWidth * Math.floor(j / numberOfRows),
+                  y: unitHeight * (j % numberOfRows),
+                }
+              } else {
+                attributes = {
+                  id: unit[idAccessor] || `w-${j}`,
+                  onMouseOver: (e) => onMouseOver(unit, e),
+                  onClick: (e) => onClick(unit, e),
+                  class: `${styles.unit} ${unit.class}`,
+                  r: unitWidth / 2,
+                  transform: `translate(${unitWidth * Math.floor(j / numberOfRows) + unitWidth / 2}, ${unitHeight * (j % numberOfRows) + unitHeight / 2})`,
+                }
+              }
+
+              return <WaffleUnit key={`wu-${j}`} type={type} attributes={attributes} />
+            })}
           </g>
         </svg>
-      }
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Request from user feedback, is that the waffle should be less jumpy, and therefore only trigger the opacity changes `onClick` not `onMouseOver`.

- Adding an onClick event to the waffle
- Adding default empty functions for the two functions, to avoid giving an error if the user doesn't want to define these.


Formatting changes make these changes look bigger than they are 