### PR TITLE
Modal: animate exit active state - for smoother exit

### DIFF
--- a/src/lib/components/molecules/modal/style.module.css
+++ b/src/lib/components/molecules/modal/style.module.css
@@ -35,8 +35,7 @@
   }
 }
 
-.enterActive,
-.exit {
+.enterActive {
   .blur {
     background-color: rgba(0, 0, 0, 0.1);
     backdrop-filter: blur(4px);
@@ -44,5 +43,15 @@
 
   .modalBox {
     transform: translateY(0);
+  }
+}
+
+.exitActive {
+  .blur {
+    background-color: transparent;
+    backdrop-filter: none;
+  }
+  .modalBox {
+    transform: translateY(100%);
   }
 }


### PR DESCRIPTION
adding an `exitActive` state to make the Modal's exit from the page smooth and more of a slide-out. 

Removing the `exit` class as this overlaps with `exitDone` and  and caused a few glitches with `exitActive`. 

CSSTransition Classes from here: https://www.npmjs.com/package/preact-transitioning

OLD - modal abruptly disappears when you click X

https://github.com/guardian/interactive-component-library/assets/10324129/2f13efea-70d0-4931-928f-cc823bd987c4

NEW - modal slides out when you click X 


https://github.com/guardian/interactive-component-library/assets/10324129/635eb3ba-5533-4489-8eed-7739a3574786





