### PR TITLE
Modal bug: clicks on transition container failing to register 

### DIFF
--- a/src/lib/components/molecules/modal/style.module.css
+++ b/src/lib/components/molecules/modal/style.module.css
@@ -6,7 +6,6 @@
   bottom: 0;
   transition: all 300ms ease-in-out;
   z-index: 9999;
-  pointer-events: none;
 }
 
 .blur {


### PR DESCRIPTION
A bug with the party tooltips meant that clicks on the blurred background area outside the tooltip failed to register 
