### PR TITLE
Ticker: the show more button bug returns

### DIFF
--- a/src/lib/components/organisms/ticker/index.jsx
+++ b/src/lib/components/organisms/ticker/index.jsx
@@ -37,12 +37,10 @@ export function Ticker({ maxItems = 20, onStateChange, children }) {
   }, [])
 
   useLayoutEffect(() => {
-    const tickerItemsContainer = tickerItemsRef.current
-
-    const hideButtons = windowSize.width >= 480 ? tickerScrollRef.current.scrollWidth <= tickerItemsContainer.clientWidth : childArray.length < 3
+    const hideButtons = childArray.length < 3
 
     setHideButtons(hideButtons)
-  }, [windowSize, setHideButtons])
+  }, [childArray])
 
   function toggleExpandedState() {
     setExpanded((expanded) => {

--- a/src/lib/components/organisms/ticker/index.jsx
+++ b/src/lib/components/organisms/ticker/index.jsx
@@ -37,7 +37,7 @@ export function Ticker({ maxItems = 20, onStateChange, children }) {
   }, [])
 
   useLayoutEffect(() => {
-    const hideButtons = childArray.length < 3
+    const hideButtons = childArray.length < 4
 
     setHideButtons(hideButtons)
   }, [childArray])


### PR DESCRIPTION
I don't know why this check was okay before, but now has started causing a problem on desktop... but it has. The show more button was hidden on desktop too frequently. 

Have amended the show more button to show any time there are 3 or more results. 

The 2nd time i've amended this
https://github.com/guardian/interactive-component-library/pull/152 
