### PR TITLE
Relative Date Stamp: force grey text with !important

### DIFF
--- a/src/lib/components/particles/relative-time-sentence/index.jsx
+++ b/src/lib/components/particles/relative-time-sentence/index.jsx
@@ -1,7 +1,7 @@
-import defaultStyles from './style.module.css'
-import { mergeStyles } from '$styles/helpers/mergeStyles.js'
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
+import defaultStyles from "./style.module.css"
+import { mergeStyles } from "$styles/helpers/mergeStyles.js"
+import dayjs from "dayjs"
+import relativeTime from "dayjs/plugin/relativeTime"
 dayjs.extend(relativeTime)
 
 export const RelativeTimeSentence = ({ timeStamp, styles }) => {
@@ -10,5 +10,5 @@ export const RelativeTimeSentence = ({ timeStamp, styles }) => {
   // dayjs docs: - range of results: https://day.js.org/docs/en/display/from-now#list-of-breakdown-range
   let timeSince = dayjs(timeStamp).fromNow()
 
-  return <span className={styles.text}>{timeSince}</span>
+  return <span className={styles.dateStampText}>{timeSince}</span>
 }

--- a/src/lib/components/particles/relative-time-sentence/style.module.css
+++ b/src/lib/components/particles/relative-time-sentence/style.module.css
@@ -1,6 +1,6 @@
-.text {
+.dateStampText {
   font-family: var(--text-sans);
   font-size: var(--sans-xsmall);
   line-height: var(--sans-line-height);
-  color: var(--secondary-text-color);
+  color: var(--secondary-text-color) !important;
 }


### PR DESCRIPTION
Sorry about this !important - annoyingly it was the only way to get this date stamp text to come out grey rather than default black. 

It was proving hard to override the styling of a nested component from the GE repo. 

<img width="492" alt="Screenshot 2024-06-26 at 18 48 48" src="https://github.com/guardian/interactive-component-library/assets/10324129/f05771b0-179b-4c2d-8510-246f270d98a8">
