### PR TITLE
Party colors: change secondary party colors at dark mode

### DIFF
--- a/src/lib/styles/foundation/partyColors.scss
+++ b/src/lib/styles/foundation/partyColors.scss
@@ -23,7 +23,7 @@
 
   --con-2: #d4edff;
   --lab-2: #ffdbd4;
-  --libdem-2: #ffe2cd;
+  --libdem-2: #ffebdd;
   --green-2: #d3f2de;
   --ukip-2: #ffe6f4;
   --snp-2: #fff7c7;
@@ -66,24 +66,24 @@
 
   --undeclared: #494949;
 
-  --con-2: #244057;
-  --lab-2: #592318;
-  --libdem-2: #64381a;
-  --green-2: #254430;
-  --ukip-2: #572d41;
-  --snp-2: #453d1c;
-  --dup-2: #4b241d;
-  --alliance-2: #484219;
-  --alba-2: #292b7f;
-  --uup-2: #253546;
-  --sdlp-2: #254a46;
-  --pc-2: #263f3c;
-  --sf-2: #1f3b27;
-  --reform-2: #2a4b57;
-  --ind-2: #383838;
+  --con-2: #2f5c81;
+  --lab-2: #833a2b;
+  --libdem-2: #8e5732;
+  --green-2: #396348;
+  --ukip-2: #8a4164;
+  --snp-2: #6b6033;
+  --dup-2: #763e34;
+  --alliance-2: #71692e;
+  --alba-2: #4749a6;
+  --uup-2: #3e5670;
+  --sdlp-2: #34736c;
+  --pc-2: #41635f;
+  --sf-2: #32593d;
+  --reform-2: #3e6877;
+  --ind-2: #666666;
   --other-2: #333333;
   --speaker-2: #333333;
-  --wpb-2: #571644;
+  --wpb-2: #752e60;
 
   --undeclared-2: #e7e7e7;
 }


### PR DESCRIPTION
Dark mode version of secondary party colors was quite murky and low-contrast - as seen in the exit poll

![Screenshot 2024-06-28 at 15 37 14](https://github.com/guardian/interactive-component-library/assets/10324129/f9696820-b1b2-4baa-b5e9-aa797733f5b1)


This lightens the colors and improves contrast 
![Screenshot 2024-06-28 at 15 46 37](https://github.com/guardian/interactive-component-library/assets/10324129/70f7cde6-da20-4a4a-b4ce-a487478d4cf1)



Also tweak to liberal democrats lightmode 