### PR TITLE
Ticker: fixes

### DIFF
--- a/src/lib/components/organisms/ticker/index.jsx
+++ b/src/lib/components/organisms/ticker/index.jsx
@@ -20,6 +20,7 @@ export function Ticker({ maxItems = 20, onStateChange, children }) {
   const tickerItemsRef = useRef()
   const tickerScrollRef = useRef()
   const controlsRef = useRef()
+  const topOfTickerAnchor = useRef()
 
   const [hideButtons, setHideButtons] = useState(false)
 
@@ -43,6 +44,9 @@ export function Ticker({ maxItems = 20, onStateChange, children }) {
   }, [childArray])
 
   function toggleExpandedState() {
+    if (expanded) {
+      topOfTickerAnchor.current.scrollIntoView({ behavior: "smooth" }) //scroll user up to top of ticker when closing at mobile
+    }
     setExpanded((expanded) => {
       const newState = !expanded
       if (onStateChange) onStateChange({ expanded: newState })
@@ -51,30 +55,33 @@ export function Ticker({ maxItems = 20, onStateChange, children }) {
   }
 
   return (
-    <div ref={tickerRef} className={styles.ticker} style={`--ticker-offset: ${offsetWidth}px;`} data-expanded={expanded}>
-      <div ref={tickerItemsRef} className={styles.tickerItems}>
-        <div ref={tickerScrollRef} className={styles.tickerScroll}>
-          {childArray.map((child, index) => (
-            <div className={styles.tickerItem} key={index}>
-              {child}
-            </div>
-          ))}
+    <>
+      <div id="top-of-ticker-anchor" ref={topOfTickerAnchor} />
+      <div ref={tickerRef} className={styles.ticker} style={`--ticker-offset: ${offsetWidth}px;`} data-expanded={expanded}>
+        <div ref={tickerItemsRef} className={styles.tickerItems}>
+          <div ref={tickerScrollRef} className={styles.tickerScroll}>
+            {childArray.map((child, index) => (
+              <div className={styles.tickerItem} key={index}>
+                {child}
+              </div>
+            ))}
+          </div>
+        </div>
+        <div ref={controlsRef} className={styles.controls} style={hideButtons && { display: "none" }}>
+          <div className={styles.gradient}>
+            <Gradient />
+          </div>
+          <div className={styles.buttons}>
+            <ArrowButton onClick={() => setPageIndex((d) => d + 1)} disabled={pageIndex >= numberOfPages - 1} />
+            <ArrowButton direction="left" onClick={() => setPageIndex((d) => d - 1)} disabled={pageIndex <= 0} />
+          </div>
+          <div className={styles.button}>
+            <Button type="regular" styles={{ buttonInner: styles.buttonInner }} onClick={toggleExpandedState}>
+              {expanded ? "Show fewer" : `Show ${maxItems} most recent`}
+            </Button>
+          </div>
         </div>
       </div>
-      <div ref={controlsRef} className={styles.controls} style={hideButtons && { display: "none" }}>
-        <div className={styles.gradient}>
-          <Gradient />
-        </div>
-        <div className={styles.buttons}>
-          <ArrowButton onClick={() => setPageIndex((d) => d + 1)} disabled={pageIndex >= numberOfPages - 1} />
-          <ArrowButton direction="left" onClick={() => setPageIndex((d) => d - 1)} disabled={pageIndex <= 0} />
-        </div>
-        <div className={styles.button}>
-          <Button type="regular" styles={{ buttonInner: styles.buttonInner }} onClick={toggleExpandedState}>
-            {expanded ? "Show fewer" : `Show ${maxItems} most recent`}
-          </Button>
-        </div>
-      </div>
-    </div>
+    </>
   )
 }

--- a/src/lib/components/organisms/ticker/index.jsx
+++ b/src/lib/components/organisms/ticker/index.jsx
@@ -20,7 +20,6 @@ export function Ticker({ maxItems = 20, onStateChange, children }) {
   const tickerItemsRef = useRef()
   const tickerScrollRef = useRef()
   const controlsRef = useRef()
-  const topOfTickerAnchor = useRef()
 
   const [hideButtons, setHideButtons] = useState(false)
 
@@ -45,7 +44,7 @@ export function Ticker({ maxItems = 20, onStateChange, children }) {
 
   function toggleExpandedState() {
     if (expanded) {
-      topOfTickerAnchor.current.scrollIntoView({ behavior: "smooth" }) //scroll user up to top of ticker when closing at mobile
+      tickerRef.current.scrollIntoView({ behavior: "smooth", alignToTop: true }) //scroll user up to top of ticker when closing at mobile
     }
     setExpanded((expanded) => {
       const newState = !expanded
@@ -55,33 +54,30 @@ export function Ticker({ maxItems = 20, onStateChange, children }) {
   }
 
   return (
-    <>
-      <div id="top-of-ticker-anchor" ref={topOfTickerAnchor} />
-      <div ref={tickerRef} className={styles.ticker} style={`--ticker-offset: ${offsetWidth}px;`} data-expanded={expanded}>
-        <div ref={tickerItemsRef} className={styles.tickerItems}>
-          <div ref={tickerScrollRef} className={styles.tickerScroll}>
-            {childArray.map((child, index) => (
-              <div className={styles.tickerItem} key={index}>
-                {child}
-              </div>
-            ))}
-          </div>
-        </div>
-        <div ref={controlsRef} className={styles.controls} style={hideButtons && { display: "none" }}>
-          <div className={styles.gradient}>
-            <Gradient />
-          </div>
-          <div className={styles.buttons}>
-            <ArrowButton onClick={() => setPageIndex((d) => d + 1)} disabled={pageIndex >= numberOfPages - 1} />
-            <ArrowButton direction="left" onClick={() => setPageIndex((d) => d - 1)} disabled={pageIndex <= 0} />
-          </div>
-          <div className={styles.button}>
-            <Button type="regular" styles={{ buttonInner: styles.buttonInner }} onClick={toggleExpandedState}>
-              {expanded ? "Show fewer" : `Show ${maxItems} most recent`}
-            </Button>
-          </div>
+    <div ref={tickerRef} className={styles.ticker} style={`--ticker-offset: ${offsetWidth}px;`} data-expanded={expanded}>
+      <div ref={tickerItemsRef} className={styles.tickerItems}>
+        <div ref={tickerScrollRef} className={styles.tickerScroll}>
+          {childArray.map((child, index) => (
+            <div className={styles.tickerItem} key={index}>
+              {child}
+            </div>
+          ))}
         </div>
       </div>
-    </>
+      <div ref={controlsRef} className={styles.controls} style={hideButtons && { display: "none" }}>
+        <div className={styles.gradient}>
+          <Gradient />
+        </div>
+        <div className={styles.buttons}>
+          <ArrowButton onClick={() => setPageIndex((d) => d + 1)} disabled={pageIndex >= numberOfPages - 1} />
+          <ArrowButton direction="left" onClick={() => setPageIndex((d) => d - 1)} disabled={pageIndex <= 0} />
+        </div>
+        <div className={styles.button}>
+          <Button type="regular" styles={{ buttonInner: styles.buttonInner }} onClick={toggleExpandedState}>
+            {expanded ? "Show fewer" : `Show ${maxItems} most recent`}
+          </Button>
+        </div>
+      </div>
+    </div>
   )
 }

--- a/src/lib/components/organisms/ticker/index.jsx
+++ b/src/lib/components/organisms/ticker/index.jsx
@@ -35,7 +35,7 @@ export function Ticker({ maxItems = 20, onStateChange, children }) {
 
     const numberOfPages = Math.ceil(tickerScrollRef.current.scrollWidth / pageWidth)
     setNumberOfPages(numberOfPages)
-  }, [])
+  }, [childArray])
 
   useLayoutEffect(() => {
     const hideButtons = childArray.length < 4

--- a/src/lib/components/organisms/ticker/style.module.scss
+++ b/src/lib/components/organisms/ticker/style.module.scss
@@ -81,6 +81,7 @@
 .button {
   min-height: 40px;
   background-color: var(--tertiary-bg-color);
+  padding-bottom: 20px;
 
   @include mq($from: mobileLandscape) {
     display: none;
@@ -93,16 +94,16 @@
 
 // Expanded state
 
-.ticker[data-expanded='true'] {
+.ticker[data-expanded="true"] {
   padding-bottom: 0;
 }
 
-.ticker[data-expanded='true'] .tickerScroll {
+.ticker[data-expanded="true"] .tickerScroll {
   max-height: fit-content;
   margin-bottom: -40px;
 }
 
-.ticker[data-expanded='true'] .controls {
+.ticker[data-expanded="true"] .controls {
   position: sticky;
   margin-top: -40px;
   // background-color: aqua;


### PR DESCRIPTION
At mobile: the show fewer button scrolls you up to the top of the ticker, so the user feels less disoriented

At desktop: a bug where the scroll to the right button would grey out, preventing you from seeing the last few items has been fixed. Adding the dependency `childArray` seemed to improve this. 
