### PR TITLE
Ticker: change child key for ticker items to use unique id

### DIFF
--- a/src/lib/components/organisms/ticker/index.jsx
+++ b/src/lib/components/organisms/ticker/index.jsx
@@ -58,7 +58,7 @@ export function Ticker({ maxItems = 20, onStateChange, children }) {
       <div ref={tickerItemsRef} className={styles.tickerItems}>
         <div ref={tickerScrollRef} className={styles.tickerScroll}>
           {childArray.map((child, index) => (
-            <div className={styles.tickerItem} key={index}>
+            <div className={styles.tickerItem} key={child?.props?.id ?? index}>
               {child}
             </div>
           ))}


### PR DESCRIPTION
A strange persistent bug with the ticker was that it didn't recognise which elements had previously been on the page. 

Each time the Ticker updated it considered all elements were new, not just the newly-added ones. 

Acccording to Max in P&E using a more unique key for this loop allows React to 
Using index when prepending to a list doesn't work bcs all items change number when something new gets added to the start of a list 

As a quick fix I'm checking if the child has an "id" prop, but falling back to index if that's not present. 

cf: https://codepen.io/mxdvl/pen/bGyXZEz

