### PR TITLE
Ticker button: fix disabled state

### DIFF
--- a/src/lib/components/organisms/ticker/index.jsx
+++ b/src/lib/components/organisms/ticker/index.jsx
@@ -69,7 +69,7 @@ export function Ticker({ maxItems = 20, onStateChange, children }) {
           <Gradient />
         </div>
         <div className={styles.buttons}>
-          <ArrowButton onClick={() => setPageIndex((d) => d + 1)} disabled={pageIndex >= numberOfPages - 1} />
+          <ArrowButton onClick={() => setPageIndex((d) => d + 1)} disabled={pageIndex >= numberOfPages - 2} />
           <ArrowButton direction="left" onClick={() => setPageIndex((d) => d - 1)} disabled={pageIndex <= 0} />
         </div>
         <div className={styles.button}>


### PR DESCRIPTION
At desktop - the right arrow button was staying ennabled for too long. It should disable sooner - turned out minus 2 makes it behave correctly 

NB: right arrow now disabled

<img width="884" alt="Screenshot 2024-07-03 at 17 34 29" src="https://github.com/guardian/interactive-component-library/assets/10324129/fb66f80c-0a92-4afa-9fc4-76cd3cef0bb6">

