### PR TITLE
useTouchOrHover hook: return if no element

### DIFF
--- a/src/lib/shared/hooks/useTouchOrHover.js
+++ b/src/lib/shared/hooks/useTouchOrHover.js
@@ -10,6 +10,8 @@ export function useTouchOrHover() {
   useEffect(() => {
     const element = ref.current
 
+    if (!element) return
+
     let touchCancelled = false
 
     const touchStarted = (event) => {


### PR DESCRIPTION
Since hooks cannot be called conditionally, ensure useTouchOrHover returns without throwing errors whenever refs are assigned conditionally