### PR TITLE
Fix: import from preact/hooks bug

### DIFF
--- a/src/lib/components/molecules/svg-map/hooks/useThrowIfNonLayerChildren.js
+++ b/src/lib/components/molecules/svg-map/hooks/useThrowIfNonLayerChildren.js
@@ -1,4 +1,4 @@
-import { useEffect } from "react"
+import { useEffect } from "preact/hooks"
 import { toChildArray } from "preact"
 
 import * as MapLayers from "../layers"


### PR DESCRIPTION
`useEffect` should be imported from "preact/hooks". 
Fix for a small bug causing problems when linking the library to a client repo