### PR TITLE
Canvas map layer components

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -19,6 +19,7 @@
     "jsxImportSource": "preact",
     "jsxFactory": "createElement",
     "skipLibCheck": true,
-    "checkJs": true
+    "checkJs": true,
+    "moduleResolution": "Bundler"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@guardian/interactive-component-library",
   "private": false,
-  "version": "v0.1.0-alpha.56",
+  "version": "0.1.0-alpha.60",
   "packageManager": "pnpm@8.4.0",
   "repository": {
     "type": "git",

--- a/src/lib/components/molecules/canvas-map/Map.jsx
+++ b/src/lib/components/molecules/canvas-map/Map.jsx
@@ -3,16 +3,26 @@ import { forwardRef } from "preact/compat"
 import { Map as _Map } from "./lib/Map"
 import { View } from "./lib/View"
 import styles from "./style.module.scss"
+import { MapProvider } from "./context/MapContext"
 
 const mobileHelpText = "Use two fingers to zoom"
 
-export const Map = forwardRef(
-  ({ config, inModalState = false, onLoad, children }, ref) => {
-    const { layers } = children
+/** @typedef {{
+ *    config: Object,
+ *    inModalState?: boolean,
+ *    onLoad?: (map: _Map) => void,
+ *    children: import('preact').ComponentChildren,
+ * }} MapProps
+ */
 
+export const Map = forwardRef(
+  (
+    /** @type {MapProps} */ { config, inModalState = false, onLoad, children },
+    ref,
+  ) => {
     const targetRef = useRef()
 
-    const [map, setMap] = useState()
+    const [map, setMap] = useState(/** @type {_Map | null} */ (null))
     const [zoomHelpText, setZoomHelpText] = useState("")
     const [showHelpText, setShowHelpText] = useState(false)
 
@@ -21,6 +31,7 @@ export const Map = forwardRef(
         view: new View(config.view),
         target: targetRef.current,
       })
+
       map.collaborativeGesturesEnabled = true
       setMap(map)
 
@@ -82,31 +93,28 @@ export const Map = forwardRef(
     }, [map, ref, onLoad])
 
     useEffect(() => {
-      if (map && layers !== map.layers) {
-        map.setLayers(layers)
-      }
-    }, [map, layers])
-
-    useEffect(() => {
       if (!map) return
       map.collaborativeGesturesEnabled = !inModalState
     }, [map, inModalState])
 
     return (
-      <figure ref={targetRef} className={styles.mapContainer}>
-        <div
-          className={styles.helpTextContainer}
-          style={{ opacity: showHelpText ? 1 : 0 }}
-          aria-hidden
-        >
-          <p className={[styles.helpText, styles.desktopHelpText].join(" ")}>
-            {zoomHelpText}
-          </p>
-          <p className={[styles.helpText, styles.mobileHelpText].join(" ")}>
-            {mobileHelpText}
-          </p>
-        </div>
-      </figure>
+      <MapProvider map={map}>
+        <figure ref={targetRef} className={styles.mapContainer}>
+          <div
+            className={styles.helpTextContainer}
+            style={{ opacity: showHelpText ? 1 : 0 }}
+            aria-hidden
+          >
+            <p className={[styles.helpText, styles.desktopHelpText].join(" ")}>
+              {zoomHelpText}
+            </p>
+            <p className={[styles.helpText, styles.mobileHelpText].join(" ")}>
+              {mobileHelpText}
+            </p>
+          </div>
+          {children}
+        </figure>
+      </MapProvider>
     )
   },
 )

--- a/src/lib/components/molecules/canvas-map/Map.jsx
+++ b/src/lib/components/molecules/canvas-map/Map.jsx
@@ -98,23 +98,21 @@ export const Map = forwardRef(
     }, [map, inModalState])
 
     return (
-      <MapProvider map={map}>
-        <figure ref={targetRef} className={styles.mapContainer}>
-          <div
-            className={styles.helpTextContainer}
-            style={{ opacity: showHelpText ? 1 : 0 }}
-            aria-hidden
-          >
-            <p className={[styles.helpText, styles.desktopHelpText].join(" ")}>
-              {zoomHelpText}
-            </p>
-            <p className={[styles.helpText, styles.mobileHelpText].join(" ")}>
-              {mobileHelpText}
-            </p>
-          </div>
-          {children}
-        </figure>
-      </MapProvider>
+      <figure ref={targetRef} className={styles.mapContainer}>
+        <div
+          className={styles.helpTextContainer}
+          style={{ opacity: showHelpText ? 1 : 0 }}
+          aria-hidden
+        >
+          <p className={[styles.helpText, styles.desktopHelpText].join(" ")}>
+            {zoomHelpText}
+          </p>
+          <p className={[styles.helpText, styles.mobileHelpText].join(" ")}>
+            {mobileHelpText}
+          </p>
+        </div>
+        <MapProvider map={map}>{children}</MapProvider>
+      </figure>
     )
   },
 )

--- a/src/lib/components/molecules/canvas-map/context/MapContext.jsx
+++ b/src/lib/components/molecules/canvas-map/context/MapContext.jsx
@@ -1,0 +1,15 @@
+import { createContext } from "preact"
+
+/**
+ * @type {import('preact').Context<{ map: import('../lib/Map').Map | null }>}
+ */
+export const MapContext = createContext(null)
+
+/**
+ * @param {Object} params
+ * @param {import('../lib/Map').Map} params.map
+ * @param {import('preact').ComponentChildren} params.children
+ */
+export function MapProvider({ map, children }) {
+  return <MapContext.Provider value={{ map }}>{children}</MapContext.Provider>
+}

--- a/src/lib/components/molecules/canvas-map/context/MapContext.jsx
+++ b/src/lib/components/molecules/canvas-map/context/MapContext.jsx
@@ -1,7 +1,12 @@
 import { createContext } from "preact"
+import { useEffect } from "preact/hooks"
 
 /**
- * @type {import('preact').Context<{ map: import('../lib/Map').Map | null }>}
+ * @typedef {{ registerLayer: ((layer: import("../lib/layers").Layer) => void) | null }} MapContext
+ */
+
+/**
+ * @type {import('preact').Context<MapContext | null>}
  */
 export const MapContext = createContext(null)
 
@@ -11,5 +16,27 @@ export const MapContext = createContext(null)
  * @param {import('preact').ComponentChildren} params.children
  */
 export function MapProvider({ map, children }) {
-  return <MapContext.Provider value={{ map }}>{children}</MapContext.Provider>
+  const registeredLayers = []
+
+  // This function is called by child layers to register themselves with the map, every time a layer
+  // is rendered
+  const registerLayer = (layer) => {
+    registeredLayers.push(layer)
+  }
+
+  // If the registered layers for this render don't match the layers in the map, then reset the
+  // map layers to the new set. If the map's layers perfectly match this render's layers, then
+  // there were no changes to the set and order of layers passed as children to Map.
+  useEffect(() => {
+    if (map && !map.hasLayers(registeredLayers)) {
+      map.setLayers(registeredLayers)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [map, children])
+
+  return (
+    <MapContext.Provider value={{ registerLayer }}>
+      {children}
+    </MapContext.Provider>
+  )
 }

--- a/src/lib/components/molecules/canvas-map/lib/Map.js
+++ b/src/lib/components/molecules/canvas-map/lib/Map.js
@@ -182,6 +182,21 @@ export class Map {
       .call(this._zoomBehaviour.transform, newTransform, focalPoint)
   }
 
+  /** @param {import("./layers").Layer[]} layers */
+  hasLayers(layers) {
+    if (layers.length !== this.layers.length) {
+      return false
+    }
+
+    for (let i = 0; i < layers.length; i++) {
+      if (layers[i] !== this.layers[i]) {
+        return false
+      }
+    }
+
+    return true
+  }
+
   async resetZoom(options) {
     return this.zoomTo(1, options)
   }

--- a/src/lib/components/molecules/canvas-map/lib/layers/TextLayer.js
+++ b/src/lib/components/molecules/canvas-map/lib/layers/TextLayer.js
@@ -4,13 +4,47 @@ import { Dispatcher } from "../events/Dispatcher"
 import { combineExtents } from "../util/extent"
 import { MapEvent } from "../events"
 import { VectorSource } from "../sources/VectorSource"
+import { MapContext } from "$molecules/canvas-map/context/MapContext"
+import { useEffect, useContext } from "preact/hooks"
+
+/** @typedef {Omit<ConstructorParameters<typeof TextLayer>[0], "source">} TextLayerOptions */
+/** @typedef {TextLayerOptions & { features: import("../Feature").Feature[]}} TextLayerComponentProps */
 
 export class TextLayer {
+  /** @param {TextLayerComponentProps} props */
+  static Component({ features, ...options }) {
+    const { map } = useContext(MapContext)
+
+    useEffect(() => {
+      if (!map) return
+
+      const model = TextLayer.with(features, options)
+      map.addLayer(model)
+
+      return () => {
+        map.removeLayer(model)
+      }
+    })
+  }
+
+  /**
+   * @param {import("../Feature").Feature[]} features
+   * @param {TextLayerOptions} options
+   */
   static with(features, options) {
     const source = new VectorSource({ features })
     return new TextLayer({ source, ...options })
   }
 
+  /**
+   * @param {Object} params
+   * @param {VectorSource} params.source
+   * @param {Style} [params.style=undefined]
+   * @param {number} [params.minZoom=0]
+   * @param {number} [params.opacity=1]
+   * @param {boolean} [params.declutter=true]
+   * @param {boolean} [params.drawCollisionBoxes=false]
+   */
   constructor({
     source,
     style,

--- a/src/lib/components/molecules/canvas-map/lib/layers/TextLayer.js
+++ b/src/lib/components/molecules/canvas-map/lib/layers/TextLayer.js
@@ -4,27 +4,50 @@ import { Dispatcher } from "../events/Dispatcher"
 import { combineExtents } from "../util/extent"
 import { MapEvent } from "../events"
 import { VectorSource } from "../sources/VectorSource"
-import { MapContext } from "$molecules/canvas-map/context/MapContext"
-import { useEffect, useContext } from "preact/hooks"
+import { MapContext } from "../../context/MapContext"
+import { useEffect, useContext, useMemo } from "preact/hooks"
 
 /** @typedef {Omit<ConstructorParameters<typeof TextLayer>[0], "source">} TextLayerOptions */
 /** @typedef {TextLayerOptions & { features: import("../Feature").Feature[]}} TextLayerComponentProps */
 
 export class TextLayer {
   /** @param {TextLayerComponentProps} props */
-  static Component({ features, ...options }) {
-    const { map } = useContext(MapContext)
+  static Component({
+    features,
+    style,
+    minZoom,
+    opacity,
+    declutter,
+    drawCollisionBoxes,
+  }) {
+    const { registerLayer } = useContext(MapContext)
+
+    // We recreate layer whenever these properties change, which cannot be changed on the fly
+    // and require recreation
+    const layer = useMemo(
+      () =>
+        TextLayer.with(features, {
+          style,
+          minZoom,
+          opacity,
+          declutter,
+          drawCollisionBoxes,
+        }),
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [features, minZoom, opacity, declutter, drawCollisionBoxes],
+    )
+
+    // Register layer with map context. If `layer` is not present in map, it will be added.
+    registerLayer(layer)
 
     useEffect(() => {
-      if (!map) return
+      // If the style prop changes, just update the layer, style can be changed without creating a
+      // new layer
+      layer.style = style
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [style])
 
-      const model = TextLayer.with(features, options)
-      map.addLayer(model)
-
-      return () => {
-        map.removeLayer(model)
-      }
-    })
+    return null
   }
 
   /**

--- a/src/lib/components/molecules/canvas-map/lib/layers/VectorLayer.js
+++ b/src/lib/components/molecules/canvas-map/lib/layers/VectorLayer.js
@@ -3,13 +3,48 @@ import { Style, Stroke } from "../styles"
 import { combineExtents } from "../util/extent"
 import { Dispatcher, MapEvent } from "../events"
 import { VectorSource } from "../sources/VectorSource"
+import { useEffect, useContext } from "preact/hooks"
+import { MapContext } from "$molecules/canvas-map/context/MapContext"
+
+/** @typedef {Omit<ConstructorParameters<typeof VectorLayer>[0], "source">} VectorLayerOptions */
+/** @typedef {VectorLayerOptions & { features: import("../Feature").Feature[] }} VectorLayerComponentProps */
 
 export class VectorLayer {
+  /** @param {VectorLayerComponentProps} props */
+  static Component({ features, ...options }) {
+    const { map } = useContext(MapContext)
+
+    useEffect(() => {
+      if (!map) return
+
+      const controller = VectorLayer.with(features, options)
+      map.addLayer(controller)
+
+      return () => {
+        map.removeLayer(controller)
+      }
+    }, [map, features, options])
+
+    return null
+  }
+
+  /**
+   * @param {import("../Feature").Feature[]} features
+   * @param {VectorLayerOptions} options
+   */
   static with(features, options) {
     const source = new VectorSource({ features })
     return new VectorLayer({ source, ...options })
   }
 
+  /**
+   * @param {Object} params
+   * @param {VectorSource} params.source
+   * @param {Style} [params.style=undefined]
+   * @param {number} [params.minZoom=0]
+   * @param {number} [params.opacity=1]
+   * @param {boolean} [params.hitDetectionEnabled=false]
+   */
   constructor({
     source,
     style,

--- a/src/lib/components/molecules/canvas-map/lib/layers/index.js
+++ b/src/lib/components/molecules/canvas-map/lib/layers/index.js
@@ -1,2 +1,4 @@
+/** @typedef { import('./TextLayer').TextLayer | import('./VectorLayer').VectorLayer } Layer */
+
 export * from "./TextLayer"
 export * from "./VectorLayer"

--- a/src/lib/components/molecules/canvas-map/map.stories.jsx
+++ b/src/lib/components/molecules/canvas-map/map.stories.jsx
@@ -1,16 +1,7 @@
-import {
-  Map,
-  Projection,
-  GeoJSON,
-  VectorSource,
-  VectorLayer,
-  Style,
-  Fill,
-  Stroke,
-} from "."
+import { Map, Projection, GeoJSON, Style, Fill, Stroke } from "."
 import { feature, merge } from "topojson-client"
-// import westminsterConstituenciesTopo from "./sample-data/uk-westminster.json"
 import westminsterConstituenciesTopo from "./sample-data/uk-westminster-simplified.json"
+import { VectorLayer } from "./lib/layers/VectorLayer"
 
 const meta = {
   title: "Molecules/CanvasMap",
@@ -44,52 +35,38 @@ export const Default = {
       westminsterConstituenciesTopo,
       westminsterConstituenciesTopo.objects["uk-westminster"].geometries,
     )
-    const outlineSource = new VectorSource({
-      features: new GeoJSON().readFeaturesFromObject(outline),
-    })
 
     const fillStyle = new Style({
       fill: new Fill({ color: "#f1f1f1" }),
     })
 
-    const outlineLayer = new VectorLayer({
-      source: outlineSource,
-      style: fillStyle,
+    const strokeStyle = new Style({
+      stroke: new Stroke({ color: "#999", width: 1 }),
     })
 
-    const strokeStyle = new Style({
-      stroke: new Stroke({
-        color: "#999",
-        width: 1,
-      }),
-    })
     const constituencies = feature(
       westminsterConstituenciesTopo,
       westminsterConstituenciesTopo.objects["uk-westminster"],
     )
-    const constituenciesSource = new VectorSource({
-      features: new GeoJSON().readFeaturesFromObject(constituencies),
-    })
-
-    const constituenciesLayer = new VectorLayer({
-      source: constituenciesSource,
-      style: (feature) => {
-        if (feature.properties.name === "North East Hertfordshire") {
-          return new Style({
-            fill: new Fill({ color: "#FF0000" }),
-          })
-        }
-        return strokeStyle
-      },
-    })
 
     return (
       <div style={{ height: "80vh" }}>
         <Map {...args}>
-          {{
-            controls: [],
-            layers: [outlineLayer, constituenciesLayer],
-          }}
+          <VectorLayer.Component
+            features={new GeoJSON().readFeaturesFromObject(outline)}
+            style={fillStyle}
+          />
+          <VectorLayer.Component
+            features={new GeoJSON().readFeaturesFromObject(constituencies)}
+            style={(feature) => {
+              if (feature.properties.name === "North East Hertfordshire") {
+                return new Style({
+                  fill: new Fill({ color: "#FF0000" }),
+                })
+              }
+              return strokeStyle
+            }}
+          />
         </Map>
       </div>
     )

--- a/src/lib/components/molecules/canvas-map/map.stories.jsx
+++ b/src/lib/components/molecules/canvas-map/map.stories.jsx
@@ -1,7 +1,19 @@
-import { Map, Projection, GeoJSON, Style, Fill, Stroke } from "."
+/* eslint-disable react-hooks/exhaustive-deps */
+import {
+  Map,
+  Projection,
+  GeoJSON,
+  Style,
+  Fill,
+  Stroke,
+  TextLayer,
+  Text,
+} from "."
 import { feature, merge } from "topojson-client"
 import westminsterConstituenciesTopo from "./sample-data/uk-westminster-simplified.json"
+import ukCitiesGeo from "./sample-data/uk-cities.json"
 import { VectorLayer } from "./lib/layers/VectorLayer"
+import { useMemo } from "preact/hooks"
 
 const meta = {
   title: "Molecules/CanvasMap",
@@ -36,36 +48,50 @@ export const Default = {
       westminsterConstituenciesTopo.objects["uk-westminster"].geometries,
     )
 
-    const fillStyle = new Style({
-      fill: new Fill({ color: "#f1f1f1" }),
-    })
-
-    const strokeStyle = new Style({
-      stroke: new Stroke({ color: "#999", width: 1 }),
-    })
-
     const constituencies = feature(
       westminsterConstituenciesTopo,
       westminsterConstituenciesTopo.objects["uk-westminster"],
     )
 
+    const outlineFeatures = useMemo(
+      () => new GeoJSON().readFeaturesFromObject(outline),
+      [],
+    )
+    const constituencyFeatures = useMemo(
+      () => new GeoJSON().readFeaturesFromObject(constituencies),
+      [],
+    )
+    const citiesFeatures = useMemo(
+      () => new GeoJSON().readFeaturesFromObject(ukCitiesGeo),
+      [],
+    )
+
+    const fillStyle = new Style({
+      fill: new Fill({ color: "#f1f1f1" }),
+    })
+    const strokeStyle = new Style({
+      stroke: new Stroke({ color: "#999", width: 1 }),
+    })
+
     return (
       <div style={{ height: "80vh" }}>
         <Map {...args}>
+          <VectorLayer.Component features={outlineFeatures} style={fillStyle} />
           <VectorLayer.Component
-            features={new GeoJSON().readFeaturesFromObject(outline)}
-            style={fillStyle}
+            features={constituencyFeatures}
+            style={(feature) =>
+              feature.properties.name === "North East Hertfordshire"
+                ? new Style({ fill: new Fill({ color: "#FF0000" }) })
+                : strokeStyle
+            }
           />
-          <VectorLayer.Component
-            features={new GeoJSON().readFeaturesFromObject(constituencies)}
-            style={(feature) => {
-              if (feature.properties.name === "North East Hertfordshire") {
-                return new Style({
-                  fill: new Fill({ color: "#FF0000" }),
-                })
-              }
-              return strokeStyle
-            }}
+          <TextLayer.Component
+            features={citiesFeatures}
+            style={(feature) =>
+              new Style({
+                text: new Text({ content: feature.properties.name }),
+              })
+            }
           />
         </Map>
       </div>

--- a/src/lib/components/molecules/canvas-map/sample-data/uk-cities.json
+++ b/src/lib/components/molecules/canvas-map/sample-data/uk-cities.json
@@ -1,0 +1,1009 @@
+{
+  "type": "FeatureCollection",
+  "name": "uk-cities",
+  "crs": {
+    "type": "name",
+    "properties": {
+      "name": "urn:ogc:def:crs:OGC:1.3:CRS84"
+    }
+  },
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "London",
+        "minZoom": 1
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -0.1277653,
+          51.5074456
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Wells"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -2.6451203,
+          51.2094511
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Leeds"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.5437941,
+          53.7974185
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Bath"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -2.3596963,
+          51.3813864
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Chester"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -2.8908955,
+          53.1908873
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Leicester"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.1331969,
+          52.6362
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Lincoln"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -0.5404819,
+          53.2293545
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Glasgow"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -4.2501687,
+          55.861155
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Norwich",
+        "minZoom": 1
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          1.2923954,
+          52.6285576
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Oxford"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.2578499,
+          51.7520131
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Portsmouth"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.0906023,
+          50.800031
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Gloucester"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -2.2458192,
+          51.8653705
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Coventry"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.510477,
+          52.4081812
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Birmingham",
+        "minZoom": 1
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.9026911,
+          52.4796992
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Edinburgh",
+        "minZoom": 1
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -3.1883749,
+          55.9533456
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Canterbury"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          1.0802533,
+          51.2800275
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Peterborough"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -0.2427336,
+          52.5725769
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Plymouth",
+        "minZoom": 1
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -4.1424451,
+          50.3714122
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Exeter"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -3.5269497,
+          50.7255794
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Milton Keynes"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -0.7594092,
+          52.0406502
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Newcastle upon Tyne",
+        "minZoom": 1
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.6131572,
+          54.9738474
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "York"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.0815361,
+          53.9590555
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Carlisle"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -2.9362311,
+          54.8948478
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Sunderland"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.3828727,
+          54.9058512
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Cambridge"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          0.1186637,
+          52.2055314
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Worcester"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -2.2206585,
+          52.1911849
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Chelmsford"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          0.4730532,
+          51.7345329
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Wakefield"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.4967286,
+          53.6829541
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Inverness"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -4.225739,
+          57.4790124
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Aberdeen"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -2.0928095,
+          57.1482429
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Swansea"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -3.9459248,
+          51.6195955
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Stirling"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -3.9360012,
+          56.1181242
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Lichfield"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.8275286,
+          52.6843696
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Durham"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.5756205,
+          54.7770139
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Perth"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -3.4286805,
+          56.3958186
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Dundee"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -2.97019,
+          56.4605938
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Hereford"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -2.7151735,
+          52.0553813
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Bangor"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -4.1268822,
+          53.2277163
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Liverpool"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -2.99168,
+          53.4071991
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Preston"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -2.6992717,
+          53.7593363
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Colchester"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          0.8994651,
+          51.8896903
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Derby"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.4761491,
+          52.9212617
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Nottingham"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.1496461,
+          52.9534193
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "St Albans"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -0.3379675,
+          51.753051
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Wolverhampton"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -2.127567,
+          52.5847651
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Dunfermline"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -3.4616183,
+          56.0713724
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Stoke-on-Trent"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -2.1812607,
+          53.0162014
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Lancaster"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -2.7990345,
+          54.0484068
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Newport"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -2.9974967,
+          51.5882332
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Hull"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -0.3394758,
+          53.7435722
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Bradford"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.7519186,
+          53.7944229
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Salford"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -2.2891921,
+          53.4877463
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Truro"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -5.0518107,
+          50.2633173
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Ripon"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.5238006,
+          54.1362169
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Chichester"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -0.7791721,
+          50.8364862
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "City of London"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -0.0919983,
+          51.5156177
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "City of Westminster"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -0.137149,
+          51.4973206
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "St Asaph"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -3.4438607,
+          53.2575614
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Sheffield"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.4702278,
+          53.3806626
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Derry/Londonderry"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -7.3213056,
+          54.9978678
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Bangor"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -5.6679127,
+          54.662595
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Armagh"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -6.6540432,
+          54.3481977
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Manchester",
+        "minZoom": 1
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -2.2451148,
+          53.4794892
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Wrexham"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -2.9937869,
+          53.0465084
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Yiewsley Ford"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -0.4919517,
+          51.518449
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Newry"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -6.337506,
+          54.1775283
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Cardiff",
+        "minZoom": 1
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -3.1791934,
+          51.4816546
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Bristol"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -2.5972985,
+          51.4538022
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Southend-on-Sea"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          0.7128137,
+          51.5388241
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Brighton"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -0.1400561,
+          50.8214626
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Belfast",
+        "minZoom": 1
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -5.9301829,
+          54.596391
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Lisburn"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -6.046717,
+          54.5112856
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Salisbury"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.7954134,
+          51.0690613
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Ely"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          0.262039,
+          52.3990199
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Winchester"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.3131692,
+          51.0612766
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "name": "Doncaster"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.1335312,
+          53.5227681
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What does this change?

This PR adds a React/JSX wrapper around the canvas map's layer components (`VectorLayer` and `TextLayer`).

Essentially, this means that we can replace this...

```jsx
 <Map {...args}>
    {{
      controls: [],
      layers: [outlineLayer, constituenciesLayer],
    }}
  </Map>
```

with this...

```jsx
<Map {...args}>
  <VectorLayer.Component
    features={new GeoJSON().readFeaturesFromObject(outline)}
    style={fillStyle}
  />
  <VectorLayer.Component
    features={new GeoJSON().readFeaturesFromObject(constituencies)}
    style={(feature) => {  /* ... */ }}
  />
</Map>
```

Much more React-y!

These components were added as a static method on the layer classes themselves, so that we can still create them using the `with` method (i.e. use these layers outside of React).

## `jsconfig.json` change

This change addresses the warnings that appear by our import statements.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/47649c99-e0e8-406e-ad8f-a772bae3959a">

We're doing exactly what it says here, except we're using `Bundler` instead of `nodenext`. 

[As TS' docs explain](https://www.typescriptlang.org/tsconfig/#moduleResolution), we need this option so we can omit file extensions in our import paths. It's otherwise identical to `nodenext`.

## JSDoc types

This PR adds the first few JSDoc types to our exported components, meaning we get lovely helpful type info when using these components! 🥳 

(For the moment these types won't make it to consumers - it seems JSDoc comments are wiped in the minify step, something I'm looking into!)

<img width="400" alt="image" src="https://github.com/user-attachments/assets/e745671f-7719-43de-94f1-af7850ba5306">

<img width="600" alt="image" src="https://github.com/user-attachments/assets/20a01a97-bd0d-4a0d-8203-c9fa6428a46d">