### PR TITLE
CircleIcon: add diameter prop

### DIFF
--- a/src/lib/components/particles/circle-icon/circle-icon.stories.jsx
+++ b/src/lib/components/particles/circle-icon/circle-icon.stories.jsx
@@ -8,6 +8,7 @@ export default {
 export const Default = {
   args: {
     color: "var(--news-core-03)",
+    diameter: 20,
   },
 }
 

--- a/src/lib/components/particles/circle-icon/index.jsx
+++ b/src/lib/components/particles/circle-icon/index.jsx
@@ -4,21 +4,23 @@ import { mergeStyles } from "$styles/helpers/mergeStyles"
 export const CircleIcon = ({ color, pulse = false, diameter = 11, styles }) => {
   styles = mergeStyles(defaultStyles, styles)
 
+  let radius = diameter / 2
+
   return (
     <svg
       style={styles.svg}
       fill="none"
-      height={diameter}
-      viewBox={`0 0 ${diameter} ${diameter}`}
-      width={diameter}
+      height={diameter + 1}
+      viewBox={`0 0 ${diameter + 2} ${diameter + 2}`}
+      width={diameter + 1}
       xmlns="http://www.w3.org/2000/svg"
     >
       <circle
         className={[styles.circle, pulse && styles.pulse].join(" ")}
         style={{ fill: color }}
-        r={diameter / 2}
-        cx={diameter / 2}
-        cy={diameter / 2}
+        r={radius}
+        cx={radius + 1}
+        cy={radius + 1}
       />
     </svg>
   )

--- a/src/lib/components/particles/circle-icon/index.jsx
+++ b/src/lib/components/particles/circle-icon/index.jsx
@@ -5,22 +5,23 @@ export const CircleIcon = ({ color, pulse = false, diameter = 11, styles }) => {
   styles = mergeStyles(defaultStyles, styles)
 
   let radius = diameter / 2
+  let padding = 2
 
   return (
     <svg
       style={styles.svg}
       fill="none"
-      height={diameter + 1}
-      viewBox={`0 0 ${diameter + 2} ${diameter + 2}`}
-      width={diameter + 1}
+      height={diameter + padding}
+      viewBox={`0 0 ${diameter + padding} ${diameter + padding}`}
+      width={diameter + padding}
       xmlns="http://www.w3.org/2000/svg"
     >
       <circle
         className={[styles.circle, pulse && styles.pulse].join(" ")}
         style={{ fill: color }}
         r={radius}
-        cx={radius + 1}
-        cy={radius + 1}
+        cx={radius + padding / 2}
+        cy={radius + padding / 2}
       />
     </svg>
   )

--- a/src/lib/components/particles/circle-icon/index.jsx
+++ b/src/lib/components/particles/circle-icon/index.jsx
@@ -1,24 +1,24 @@
 import defaultStyles from "./style.module.css"
 import { mergeStyles } from "$styles/helpers/mergeStyles"
 
-export const CircleIcon = ({ color, pulse = false, styles }) => {
+export const CircleIcon = ({ color, pulse = false, diameter = 11, styles }) => {
   styles = mergeStyles(defaultStyles, styles)
 
   return (
     <svg
       style={styles.svg}
       fill="none"
-      height="11"
-      viewBox="0 0 11 11"
-      width="11"
+      height={diameter}
+      viewBox={`0 0 ${diameter} ${diameter}`}
+      width={diameter}
       xmlns="http://www.w3.org/2000/svg"
     >
-      <rect
+      <circle
         className={[styles.circle, pulse && styles.pulse].join(" ")}
         style={{ fill: color }}
-        height="11"
-        rx="5.5"
-        width="11"
+        r={diameter / 2}
+        cx={diameter / 2}
+        cy={diameter / 2}
       />
     </svg>
   )

--- a/src/lib/components/particles/gradient-icon/style.module.css
+++ b/src/lib/components/particles/gradient-icon/style.module.css
@@ -5,7 +5,7 @@
 
 .svg {
   display: "inline-block";
-  transform: "translateY(-1px)";
+  transform: translateY(-1px);
   fill: none;
 }
 


### PR DESCRIPTION
CircleIcon
- adding a diameter property (defaulting to 11) so that the size of this circle can be adjusted by the client
- allowed some adjustment space in viewport and svg height + width properties
- changed this from a rect to a circle element. This seemed more semantic to me. Unless I'm missing some good reason why it was a rect? 

GradientIcon
- some CSS that helped with positioning was invalid, so fixed this. It makes it sit better in the line. 


looks like:
<img width="268" alt="Screenshot 2024-08-12 at 16 05 06" src="https://github.com/user-attachments/assets/03967ce3-bd99-4c72-b8f9-02b8d9041410">
