### PR TITLE
Fix version bump action's changes to package.json

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -24,15 +24,11 @@ jobs:
         with:
           ref: refs/tags/${{ env.TAG_NAME }}
 
-      - name: Change version in package.json
-        uses: jossef/action-set-json-field@v2
-        with:
-          file: package.json
-          field: version
-          value: ${{ env.TAG_NAME }}
+      - name: Update package.json version
+        run: npm version --commit-hooks false --git-tag-version false "${{ env.TAG_NAME }}"
 
-      - name: Print package.json
-        run: cat package.json
+      - name: Show version bump diff
+        run: git diff
 
       - name: Create Pull Request for new version
         uses: peter-evans/create-pull-request@v6
@@ -43,6 +39,7 @@ jobs:
           base: main
           title: "Bump version to ${{ env.TAG_NAME }}"
           body: "Automated pull requested created because a tag with the name ${{ env.TAG_NAME }} was pushed to the repo."
+
   build:
     needs: bump-version
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR makes sure that our "Publish package to NPM" action doesn't corrupt the package.json, by removing the newline at the end of file.

Doing so makes Prettier confused and causes the lint action to stall, as can be seen in this PR: https://github.com/guardian/interactive-component-library/pull/231.