### PR TITLE
Ignore auto-version-* branches in lint workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
-on: pull_request
+on:
+  pull_request:
+    branches-ignore:
+      - "auto-version-*"
 jobs:
   ci:
     name: Run linter and formatter


### PR DESCRIPTION
[As it turns out, our workflows simply cannot be triggered for PR branches created by bots.](https://github.com/peter-evans/create-pull-request/issues/48)

There are solutions that involve creating a new user for bot PRs such as these, but it's easier to just assume that these PR branches don't need to be linted, which they really don't!