### PR TITLE
US colors: fix typo in color var

### DIFF
--- a/src/lib/styles/foundation/usPartyColors.scss
+++ b/src/lib/styles/foundation/usPartyColors.scss
@@ -42,7 +42,7 @@
 }
 
 .bg-color--gop-2 {
-  background-color: var(--gop2) !important;
+  background-color: var(--gop-2) !important;
 }
 
 .bg-color--oth-2 {


### PR DESCRIPTION
* small mistake in color declaration 