### PR TITLE
Disable browser autocomplete for SearchInput

### DIFF
--- a/src/lib/components/molecules/search-input/index.jsx
+++ b/src/lib/components/molecules/search-input/index.jsx
@@ -85,6 +85,7 @@ export function SearchInput({
         ref={inputRef}
         type="text"
         aria-label="Search input"
+        autoComplete="off"
         value={inputValue}
         onKeyDown={onKeyDown}
         onInput={(e) => {


### PR DESCRIPTION
This PR adds the `autocomplete="off"` attribute to the SearchInput's `<input>`, so that the native browser autocomplete UI doesn't get in the way of the component's, as shown below.

<img width="451" alt="image" src="https://github.com/user-attachments/assets/4960b784-32e5-42cf-94f1-01bce0dca7ea">
