### PR TITLE
Fix hit detection for preprojected maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "d3-scale": "^4.0.2",
     "d3-selection": "^3.0.0",
     "d3-zoom": "^3.0.0",
+    "d3-polygon": "^3.0.1",
     "preact": "10.21.0"
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,9 @@ dependencies:
   d3-composite-projections:
     specifier: ^1.4.0
     version: 1.4.0
+  d3-polygon:
+    specifier: ^3.0.1
+    version: 3.0.1
   d3-selection:
     specifier: ^3.0.0
     version: 3.0.0
@@ -3892,6 +3895,11 @@ packages:
 
   /d3-path@2.0.0:
     resolution: {integrity: sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA==}
+    dev: false
+
+  /d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
     dev: false
 
   /d3-scale@4.0.2:

--- a/src/lib/components/molecules/canvas-map/index.js
+++ b/src/lib/components/molecules/canvas-map/index.js
@@ -1,4 +1,5 @@
-export * from "./Map"
+/* eslint-disable no-unused-vars */
+export * from "./lib/Map"
 export * from "./controls"
 export * from "./lib/Feature"
 export * from "./lib/FeatureCollection"
@@ -6,7 +7,10 @@ export * from "./lib/events"
 export * from "./lib/projection"
 export * from "./lib/layers"
 export * from "./lib/styles"
+export * from "./lib/util"
 export * from "./lib/interpolators"
 export * from "./lib/sources/VectorSource"
 export * from "./lib/formats/GeoJSON"
-export * from "./lib/util/bboxFeature"
+
+// define Map.Component
+import * as _ from "./Map"

--- a/src/lib/components/molecules/canvas-map/lib/Feature.js
+++ b/src/lib/components/molecules/canvas-map/lib/Feature.js
@@ -1,6 +1,6 @@
 import { createUid } from "./util/uid"
 import { combineExtents, containsCoordinate } from "./util/extent"
-import { geoContains } from "d3-geo"
+import { polygonContains } from "d3-polygon"
 import { memoise } from "./util/memoise"
 
 /**
@@ -42,6 +42,11 @@ export class Feature {
     this._extent = undefined
   }
 
+  /**
+   * Get the extent of the geometries in the feature.
+
+   * @returns {import("./util").Extent}
+   */
   getExtent() {
     if (this._extent) return this._extent
 
@@ -67,27 +72,13 @@ export class Feature {
   }
 
   containsCoordinate(coordinate) {
-      // console.log("containsCoordinate", coordinate)
-    if (this.properties.name === "Oregon") {
-      console.log("Oregon contains coordinate?", coordinate)
-    }
     if (!containsCoordinate(this.getExtent(), coordinate)) {
-        if (this.properties.name === "Oregon") {
-                console.log(
-                  "Oregon extent does not contain coordinate",
-                  coordinate,
-                  this.getExtent(),
-                )
-
-        }
       return false
     }
 
     for (const geometry of this.geometries) {
-          if (this.properties.name === "Oregon") {
-            console.log("Oregon geometry", geometry.getGeoJSON())
-          }
-      if (geoContains(geometry.getGeoJSON(), coordinate)) {
+      // Only the outer ring of the geometry is considered, because we don't care about holes in the shape
+      if (polygonContains(geometry.getOuterRing(), coordinate)) {
         return true
       }
     }

--- a/src/lib/components/molecules/canvas-map/lib/Feature.js
+++ b/src/lib/components/molecules/canvas-map/lib/Feature.js
@@ -67,12 +67,27 @@ export class Feature {
   }
 
   containsCoordinate(coordinate) {
+      // console.log("containsCoordinate", coordinate)
+    if (this.properties.name === "Oregon") {
+      console.log("Oregon contains coordinate?", coordinate)
+    }
     if (!containsCoordinate(this.getExtent(), coordinate)) {
+        if (this.properties.name === "Oregon") {
+                console.log(
+                  "Oregon extent does not contain coordinate",
+                  coordinate,
+                  this.getExtent(),
+                )
+
+        }
       return false
     }
 
-    for (const geometries of this.geometries) {
-      if (geoContains(geometries.getGeoJSON(), coordinate)) {
+    for (const geometry of this.geometries) {
+          if (this.properties.name === "Oregon") {
+            console.log("Oregon geometry", geometry.getGeoJSON())
+          }
+      if (geoContains(geometry.getGeoJSON(), coordinate)) {
         return true
       }
     }

--- a/src/lib/components/molecules/canvas-map/lib/FeatureCollection.js
+++ b/src/lib/components/molecules/canvas-map/lib/FeatureCollection.js
@@ -8,7 +8,7 @@ import { GeoJSON } from "./formats/GeoJSON"
 export class FeatureCollection {
   /**
    * Create a feature collection from GeoJSON features.
-   * @param {Object[]} geoJSON - The GeoJSON object
+   * @param {Object | Object[]} geoJSON - The GeoJSON object
    * @param {import("./formats/GeoJSON").GeoJSONParseOptions} [parseOptions] - Options for parsing the GeoJSON object
    * @returns {FeatureCollection} The feature collection
    */

--- a/src/lib/components/molecules/canvas-map/lib/FeatureCollection.js
+++ b/src/lib/components/molecules/canvas-map/lib/FeatureCollection.js
@@ -9,10 +9,11 @@ export class FeatureCollection {
   /**
    * Create a feature collection from GeoJSON features.
    * @param {Object[]} geoJSON - The GeoJSON object
+   * @param {import("./formats/GeoJSON").GeoJSONParseOptions} [parseOptions] - Options for parsing the GeoJSON object
    * @returns {FeatureCollection} The feature collection
    */
-  static fromGeoJSON(geoJSON) {
-    const features = new GeoJSON().readFeaturesFromObject(geoJSON)
+  static fromGeoJSON(geoJSON, parseOptions) {
+    const features = new GeoJSON(parseOptions).readFeaturesFromObject(geoJSON)
     return new FeatureCollection(features)
   }
 

--- a/src/lib/components/molecules/canvas-map/lib/Map.js
+++ b/src/lib/components/molecules/canvas-map/lib/Map.js
@@ -12,13 +12,15 @@ import "d3-transition"
 /**
  * Map component that renders into a canvas
  * It has built-in support for zooming and panning, as well as support for vector layers
- * @constructor
- * @param {Object} config - The configuration for the map.
- * @param {Object} config.view - The view configuration for the map.
- * @param {boolean} config.debug - Whether to enable debug mode or not.
- * @param {HTMLElement} config.target - The target element to render the map into.
  */
 export class Map {
+  /**
+   * @constructor
+   * @param {Object} config - The configuration for the map.
+   * @param {Object} config.view - The view configuration for the map.
+   * @param {boolean} config.debug - Whether to enable debug mode or not.
+   * @param {HTMLElement} config.target - The target element to render the map into.
+   */
   constructor(config) {
     if (config.debug) {
       // eslint-disable-next-line no-console
@@ -363,3 +365,5 @@ export class Map {
     this._animationFrameRequestID = null
   }
 }
+
+Map.Component = undefined

--- a/src/lib/components/molecules/canvas-map/lib/formats/GeoJSON.js
+++ b/src/lib/components/molecules/canvas-map/lib/formats/GeoJSON.js
@@ -23,14 +23,14 @@ import { extentForCoordinates } from "../util/extent"
 export class GeoJSON {
   /**
    * @constructor
-   * @param {GeoJSONParseOptions} parseOptions
+   * @param {GeoJSONParseOptions} [parseOptions]
    */
-  constructor({ isProjected = false }) {
-    this.isProjected = isProjected
+  constructor(parseOptions = {}) {
+    this.isProjected = parseOptions?.isProjected
   }
 
   /**
-   * Convert GeoJSON object(s) to array of {@link Feature} objects
+   * Convert GeoJSON object(s) to array of {@link Feature} objects.
    *
    * @function
    * @param {GeoJSONFeature | GeoJSONFeatureCollection | GeoJSONFeature[]} object GeoJSON object
@@ -80,7 +80,7 @@ export class GeoJSON {
   }
 
   /**
-   * Convert single GeoJSON feature to {@link Feature} object
+   * Convert single GeoJSON feature to {@link Feature} object.
    *
    * @function
    * @param {GeoJSONFeature} geoJSONObject GeoJSON object

--- a/src/lib/components/molecules/canvas-map/lib/formats/GeoJSON.js
+++ b/src/lib/components/molecules/canvas-map/lib/formats/GeoJSON.js
@@ -2,7 +2,40 @@ import { Feature } from "../Feature"
 import { Polygon, LineString, Point } from "../geometry"
 import { extentForCoordinates } from "../util/extent"
 
+/**
+ * @typedef {Object} GeoJSONFeature
+ * @property {string} type
+ * @property {Object} geometry
+ * @property {Record<string, any>} properties
+ */
+
+/**
+ * @typedef {Object} GeoJSONFeatureCollection
+ * @property {string} type
+ * @property {GeoJSONFeature[]} features
+ */
+
+/**
+ * @typedef GeoJSONParseOptions
+ * @property {boolean} [isProjected=false] - Tells the parser whether the geometry is already projected or not
+ */
+
 export class GeoJSON {
+  /**
+   * @constructor
+   * @param {GeoJSONParseOptions} parseOptions
+   */
+  constructor({ isProjected = false }) {
+    this.isProjected = isProjected
+  }
+
+  /**
+   * Convert GeoJSON object(s) to array of {@link Feature} objects
+   *
+   * @function
+   * @param {GeoJSONFeature | GeoJSONFeatureCollection | GeoJSONFeature[]} object GeoJSON object
+   * @returns {Feature[]}
+   */
   readFeaturesFromObject(object) {
     const geoJSONObject = object
     let features = null
@@ -18,7 +51,11 @@ export class GeoJSON {
         features.push(featureObject)
       }
     } else if (geoJSONObject["type"] === "Feature") {
-      features = [this.readFeatureFromObject(geoJSONObject)]
+      features = [
+        this.readFeatureFromObject(
+          /** @type {GeoJSONFeature} */ (geoJSONObject),
+        ),
+      ]
     } else if (Array.isArray(geoJSONObject)) {
       features = []
       for (let i = 0, ii = geoJSONObject.length; i < ii; ++i) {
@@ -42,6 +79,13 @@ export class GeoJSON {
     return features.flat()
   }
 
+  /**
+   * Convert single GeoJSON feature to {@link Feature} object
+   *
+   * @function
+   * @param {GeoJSONFeature} geoJSONObject GeoJSON object
+   * @returns {Feature | null}
+   */
   readFeatureFromObject(geoJSONObject) {
     const geometries = this.readGeometriesFromObject(geoJSONObject["geometry"])
     if (geometries.length > 0) {

--- a/src/lib/components/molecules/canvas-map/lib/geometry/Geometry.js
+++ b/src/lib/components/molecules/canvas-map/lib/geometry/Geometry.js
@@ -6,7 +6,7 @@ export class Geometry {
    * @constructor
    * @param {Object} options
    * @param {string} options.type - The type of geometry (e.g., 'Point', 'LineString', 'Polygon')
-   * @param {Array} options.extent - The extent of the geometry (e.g., [xmin, ymin, xmax, ymax])
+   * @param {import("../util").Extent} options.extent - The extent of the geometry (e.g., [xmin, ymin, xmax, ymax])
    * @param {Array} options.coordinates - The coordinates of the geometry (e.g., [[x1, y1], [x2, y2], ...])
    */
   constructor({ type, extent, coordinates }) {

--- a/src/lib/components/molecules/canvas-map/lib/layers/VectorLayer.js
+++ b/src/lib/components/molecules/canvas-map/lib/layers/VectorLayer.js
@@ -134,6 +134,10 @@ export class VectorLayer {
     }
   }
 
+  /**
+   * Get the extent of the features in the layer.
+   * @returns {import("../util").Extent | null} The extent of the features in the layer, or null if the layer is empty.
+   */
   getExtent() {
     if (this._extent) return this._extent
 

--- a/src/lib/components/molecules/canvas-map/lib/projection/index.js
+++ b/src/lib/components/molecules/canvas-map/lib/projection/index.js
@@ -1,6 +1,13 @@
 import { geoAlbers, geoMercator, geoIdentity, geoAlbersUsa } from "d3-geo"
 import { geoAlbersUk } from "d3-composite-projections"
 
+/** @typedef {(point: [number, number]) => [number, number] | null} ProjectionFunction */
+
+/**
+ * Projection functions for different map projections.
+ * @readonly
+ * @enum {ProjectionFunction}
+ */
 export const Projection = {
   geoIdentity: geoIdentity(),
   geoMercator: geoMercator(),

--- a/src/lib/components/molecules/canvas-map/lib/sources/VectorSource.js
+++ b/src/lib/components/molecules/canvas-map/lib/sources/VectorSource.js
@@ -21,13 +21,11 @@ export class VectorSource {
 
   getFeaturesAtCoordinate(coordinate) {
     const [lon, lat] = coordinate
-    console.log('get features at coordinate', lon, lat)
-    const features = knn(this._featuresRtree, lon, lat, 10, (d) =>
-      {
-        // return true //console.log(d.feature.properties.name)
-        return d.feature.containsCoordinate(coordinate)
-      },
-    ).map((d) => {
+    // console.log('get features at coordinate', lon, lat)
+    const features = knn(this._featuresRtree, lon, lat, 10, (d) => {
+      // return true //console.log(d.feature.properties.name)
+      return d.feature.containsCoordinate(coordinate)
+    }).map((d) => {
       const midX = d.minX + (d.minX + d.maxX) / 2
       const midY = d.minY + (d.minY + d.maxY) / 2
       d.distance = Math.hypot(midX - lon, midY - lat)
@@ -35,14 +33,15 @@ export class VectorSource {
     })
 
     features.sort((a, b) => a.distance - b.distance)
-    for (const feature of features.slice(0, 1)) {
-      console.log(feature.feature.properties.name, feature.distance)
-    }
+    // for (const feature of features.slice(0, 1)) {
+    //   console.log(feature.feature.properties?.name, feature.distance)
+    // }
     return features.map((d) => d.feature)
   }
 
   getFeaturesInExtent(extent) {
     const [minX, minY, maxX, maxY] = extent
+
     return this._featuresRtree
       .search({ minX, minY, maxX, maxY })
       .map((d) => d.feature)
@@ -52,9 +51,6 @@ export class VectorSource {
     this._featuresRtree.clear()
 
     for (const feature of features) {
-      if (feature.properties.name === "Oregon") {
-        console.log("Oregon", feature.getExtent())
-      }
       const [minX, minY, maxX, maxY] = feature.getExtent()
       this._featuresRtree.insert({
         minX: Math.floor(minX),

--- a/src/lib/components/molecules/canvas-map/lib/sources/VectorSource.js
+++ b/src/lib/components/molecules/canvas-map/lib/sources/VectorSource.js
@@ -20,38 +20,35 @@ export class VectorSource {
   }
 
   getFeaturesAtCoordinate(coordinate) {
-    const [lon, lat] = coordinate
-    // console.log('get features at coordinate', lon, lat)
-    const features = knn(this._featuresRtree, lon, lat, 10, (d) => {
-      // return true //console.log(d.feature.properties.name)
+    const [x, y] = coordinate
+    const items = knn(this._featuresRtree, x, y, 10, (d) => {
       return d.feature.containsCoordinate(coordinate)
     }).map((d) => {
       const midX = d.minX + (d.minX + d.maxX) / 2
       const midY = d.minY + (d.minY + d.maxY) / 2
-      d.distance = Math.hypot(midX - lon, midY - lat)
+      d.distance = Math.hypot(midX - x, midY - y)
       return d
     })
 
-    features.sort((a, b) => a.distance - b.distance)
-    // for (const feature of features.slice(0, 1)) {
-    //   console.log(feature.feature.properties?.name, feature.distance)
-    // }
-    return features.map((d) => d.feature)
+    items.sort((a, b) => a.distance - b.distance)
+    return items.map((d) => d.feature)
   }
 
   getFeaturesInExtent(extent) {
     const [minX, minY, maxX, maxY] = extent
 
-    return this._featuresRtree
+    const features = this._featuresRtree
       .search({ minX, minY, maxX, maxY })
       .map((d) => d.feature)
+
+    return features
   }
 
   setFeatures(features) {
     this._featuresRtree.clear()
 
     for (const feature of features) {
-      const [minX, minY, maxX, maxY] = feature.getExtent()
+      const { minX, minY, maxX, maxY } = feature.getExtent()
       this._featuresRtree.insert({
         minX: Math.floor(minX),
         minY: Math.floor(minY),

--- a/src/lib/components/molecules/canvas-map/lib/sources/VectorSource.js
+++ b/src/lib/components/molecules/canvas-map/lib/sources/VectorSource.js
@@ -21,15 +21,23 @@ export class VectorSource {
 
   getFeaturesAtCoordinate(coordinate) {
     const [lon, lat] = coordinate
+    console.log('get features at coordinate', lon, lat)
     const features = knn(this._featuresRtree, lon, lat, 10, (d) =>
-      d.feature.containsCoordinate(coordinate),
+      {
+        // return true //console.log(d.feature.properties.name)
+        return d.feature.containsCoordinate(coordinate)
+      },
     ).map((d) => {
       const midX = d.minX + (d.minX + d.maxX) / 2
       const midY = d.minY + (d.minY + d.maxY) / 2
       d.distance = Math.hypot(midX - lon, midY - lat)
       return d
     })
+
     features.sort((a, b) => a.distance - b.distance)
+    for (const feature of features.slice(0, 1)) {
+      console.log(feature.feature.properties.name, feature.distance)
+    }
     return features.map((d) => d.feature)
   }
 
@@ -44,6 +52,9 @@ export class VectorSource {
     this._featuresRtree.clear()
 
     for (const feature of features) {
+      if (feature.properties.name === "Oregon") {
+        console.log("Oregon", feature.getExtent())
+      }
       const [minX, minY, maxX, maxY] = feature.getExtent()
       this._featuresRtree.insert({
         minX: Math.floor(minX),

--- a/src/lib/components/molecules/canvas-map/lib/styles/Text.js
+++ b/src/lib/components/molecules/canvas-map/lib/styles/Text.js
@@ -50,7 +50,7 @@ export class Text {
   /**
    * Create a text element style
    * @constructor
-   * @param {TextStyle} options - Style options
+   * @param {TextStyle} [options] - Style options
    */
   constructor(options) {
     this.content = options?.content

--- a/src/lib/components/molecules/canvas-map/lib/util/bboxFeature.js
+++ b/src/lib/components/molecules/canvas-map/lib/util/bboxFeature.js
@@ -1,15 +1,14 @@
-import { GeoBounds } from "./bounds"
+import { Extent } from "."
 
 /**
  * Function to create a GeoJSON feature from a GeoBoundsLike object.
  * @function
- * @param {import("./bounds").GeoBoundsLike} bounds
+ * @param {import("./extent").ExtentLike} extent
  * @returns {import("../formats/GeoJSON").GeoJSONFeature} A GeoJSON feature representing a rectangle for the given bounds.
  * @note The reverse winding order of coordinates. This is essential in D3 https://stackoverflow.com/questions/49311001/d3-js-drawing-geojson-incorrectly
  */
-export function bboxFeature(bounds) {
-  const geoBounds = GeoBounds.convert(bounds)
-  const [minLon, minLat, maxLon, maxLat] = geoBounds.flat()
+export function bboxFeature(extent) {
+  const { minX, minY, maxX, maxY } = Extent.convert(extent)
 
   const feature = {
     type: "Feature",
@@ -17,11 +16,11 @@ export function bboxFeature(bounds) {
     geometry: {
       coordinates: [
         [
-          [minLon, maxLat],
-          [maxLon, maxLat],
-          [maxLon, minLat],
-          [minLon, minLat],
-          [minLon, maxLat],
+          [minX, minY],
+          [minX, maxY],
+          [maxX, maxY],
+          [maxX, minY],
+          [minX, minY],
         ],
       ],
       type: "Polygon",

--- a/src/lib/components/molecules/canvas-map/lib/util/bboxFeature.js
+++ b/src/lib/components/molecules/canvas-map/lib/util/bboxFeature.js
@@ -1,12 +1,15 @@
-// bounds in [[SW lon, SW lat], [NE lon], [NE lat]] format
-// e.g. UK bounding box: [[-8.642194417322951, 49.88234469492934], [1.7683086664999994, 60.8456995072]]
-// Note the reverse winding order of coordinates. This is essential in D3 https://stackoverflow.com/questions/49311001/d3-js-drawing-geojson-incorrectly
+import { GeoBounds } from "./bounds"
 
+/**
+ * Function to create a GeoJSON feature from a GeoBoundsLike object.
+ * @function
+ * @param {import("./bounds").GeoBoundsLike} bounds
+ * @returns {import("../formats/GeoJSON").GeoJSONFeature} A GeoJSON feature representing a rectangle for the given bounds.
+ * @note The reverse winding order of coordinates. This is essential in D3 https://stackoverflow.com/questions/49311001/d3-js-drawing-geojson-incorrectly
+ */
 export function bboxFeature(bounds) {
-  const minLon = bounds[0][0]
-  const minLat = bounds[0][1]
-  const maxLon = bounds[1][0]
-  const maxLat = bounds[1][1]
+  const geoBounds = GeoBounds.convert(bounds)
+  const [minLon, minLat, maxLon, maxLat] = geoBounds.flat()
 
   const feature = {
     type: "Feature",

--- a/src/lib/components/molecules/canvas-map/lib/util/bounds.js
+++ b/src/lib/components/molecules/canvas-map/lib/util/bounds.js
@@ -1,4 +1,5 @@
 import { GeoCoordinate } from "./coordinate"
+import { Extent } from "./extent"
 
 /**
  * @typedef {import("./coordinate").GeoCoordinateLike} Coordinate
@@ -35,6 +36,15 @@ export class GeoBounds {
     ]
   }
 
+  toExtent() {
+    return new Extent(
+      this.southWest.lng,
+      this.southWest.lat,
+      this.northEast.lng,
+      this.northEast.lat,
+    )
+  }
+
   /**
    * Converts an array to a `GeoBounds` object.
    *
@@ -61,13 +71,5 @@ export class GeoBounds {
     }
 
     throw new Error("`input` argument must be of type `GeoBoundsLike`")
-  }
-
-  static fromExtent(extent) {
-    const { minX, minY, maxX, maxY } = extent
-    return new GeoBounds({
-      southWest: new GeoCoordinate(minX, maxY),
-      northEast: new GeoCoordinate(maxX, minY),
-    })
   }
 }

--- a/src/lib/components/molecules/canvas-map/lib/util/bounds.js
+++ b/src/lib/components/molecules/canvas-map/lib/util/bounds.js
@@ -1,0 +1,73 @@
+import { GeoCoordinate } from "./coordinate"
+
+/**
+ * @typedef {import("./coordinate").GeoCoordinateLike} Coordinate
+ * @typedef {[number, number, number, number] | [Coordinate, Coordinate] | {sw: Coordinate, ne: Coordinate}} GeoBoundsLike
+ */
+
+/**
+ * A GeoBounds object represents a geographical bounding box, defined by its southwest and northeast points in longitude and latitude.
+ *
+ * @property {GeoCoordinate} southWest
+ * @property {GeoCoordinate} northEast
+ */
+export class GeoBounds {
+  /**
+   * @constructor
+   * @param {Object} bounds
+   * @param {GeoCoordinate} bounds.southWest
+   * @param {GeoCoordinate} bounds.northEast
+   */
+  constructor({ southWest, northEast }) {
+    this.southWest = southWest
+    this.northEast = northEast
+  }
+
+  /**
+   * @returns {[number, number, number, number]}
+   */
+  flat() {
+    return [
+      this.southWest.lng,
+      this.southWest.lat,
+      this.northEast.lng,
+      this.northEast.lat,
+    ]
+  }
+
+  /**
+   * Converts an array to a `GeoBounds` object.
+   *
+   * If a `GeoBounds` object is passed in, the function returns it unchanged.
+   *
+   * Internally, the function calls `GeoCoordinate#convert` to convert arrays to `GeoCoordinate` values.
+   *
+   * @param {GeoBoundsLike} input - An array of two coordinates to convert
+   * @returns {GeoBounds | null} A new `GeoBounds` object, if a conversion occurred, or the original `GeoBounds` object.
+   */
+  static convert(input) {
+    if (input instanceof GeoBounds) return input
+    if (!input) return null
+
+    if (Array.isArray(input)) {
+      const [sw, ne] = input.map((d) => GeoCoordinate.convert(d))
+      return new GeoBounds({ southWest: sw, northEast: ne })
+    } else if (typeof input === "object" && input !== null) {
+      const { sw, ne } = input
+      return new GeoBounds({
+        southWest: GeoCoordinate.convert(sw),
+        northEast: GeoCoordinate.convert(ne),
+      })
+    }
+
+    throw new Error("`input` argument must be of type `GeoBoundsLike`")
+  }
+
+  static fromExtent(extent) {
+    const { minX, minY, maxX, maxY } = extent
+    return new GeoBounds({
+      southWest: new GeoCoordinate(minX, maxY),
+      northEast: new GeoCoordinate(maxX, minY),
+    })
+  }
+}

--- a/src/lib/components/molecules/canvas-map/lib/util/coordinate.js
+++ b/src/lib/components/molecules/canvas-map/lib/util/coordinate.js
@@ -1,0 +1,42 @@
+/** @typedef {[number, number] | {lng: number, lat: number}} GeoCoordinateLike */
+
+/**
+ * A `GeoCoordinate` object represents a given longitude and latitude coordinate, measured in degrees.
+ * These coordinates are based on the [WGS84 (EPSG:4326) standard](https://en.wikipedia.org/wiki/World_Geodetic_System#WGS84).
+ *
+ * @class
+ */
+export class GeoCoordinate {
+  constructor(longitude, latitude) {
+    if (isNaN(longitude) || isNaN(latitude)) {
+      throw new Error(`Invalid GeoCoordinate: (${longitude}, ${latitude})`)
+    }
+
+    this.lng = longitude
+    this.lat = latitude
+  }
+
+  /**
+   * Converts an array of two numbers or an object with `lng` and `lat` properties
+   * to a `GeoCoordinate` object.
+   *
+   * If a `GeoCoordinate` object is passed in, the function returns it unchanged.
+   *
+   * @param {GeoCoordinateLike} input - An array of two numbers ([lng<number>, lat<number>]), a  {lng: number, lat: number} object, or an instance of `GeoCoordinate`.
+   * @returns {GeoCoordinate} A new `GeoCoordinate` object, if a conversion occurred, or the original `GeoCoordinate` object.
+   */
+  static convert(input) {
+    if (input instanceof GeoCoordinate) {
+      return input
+    }
+    if (Array.isArray(input) && (input.length === 2 || input.length === 3)) {
+      return new GeoCoordinate(Number(input[0]), Number(input[1]))
+    }
+    if (!Array.isArray(input) && typeof input === "object" && input !== null) {
+      return new GeoCoordinate(Number(input.lng), Number(input.lat))
+    }
+    throw new Error(
+      "`input` argument must be specified as an object {lng: <lng>, lat: <lat>} or an array [lng<number>, lat<number>]",
+    )
+  }
+}

--- a/src/lib/components/molecules/canvas-map/lib/util/extent.js
+++ b/src/lib/components/molecules/canvas-map/lib/util/extent.js
@@ -1,3 +1,59 @@
+/**
+ * @typedef {[number, number, number, number] | [[number, number], [number, number]] |  {minX: number, minY: number, maxX: number, maxY: number}} ExtentLike
+ */
+
+/**
+ * @class Extent
+ * @property {number} minX The minimum x value of the extent.
+ * @property {number} minY The minimum y value of the extent.
+ * @property {number} maxX The maximum x value of the extent.
+ * @property {number} maxY The maximum y value of the extent.
+ * @property {ExtentLike} array The extent as an array of numbers.
+ *
+ * @example
+ * // The extent of a 975x610 viewport
+ * const viewPortExtent = new Extent([0, 0, 975, 610])
+ */
+export class Extent {
+  constructor(minX, minY, maxX, maxY) {
+    this.minX = minX
+    this.minY = minY
+    this.maxX = maxX
+    this.maxY = maxY
+  }
+
+  flat() {
+    return [this.minX, this.minY, this.maxX, this.maxY]
+  }
+
+  /**
+   * Converts {@link ExtentLike} to an {@link Extent} object.
+   *
+   * If an {@link Extent} object is passed in, the function returns it unchanged.
+   *
+   *
+   * @param {ExtentLike} input - Extent defined as {@link ExtentLike}.
+   * @returns A new `Extent` object, if a conversion occurred, or the original `Extent` object.
+   */
+  static convert(input) {
+    if (input instanceof Extent) return input
+    if (!input) return input
+
+    if (Array.isArray(input) && input.length === 4) {
+      const [minX, minY, maxX, maxY] = input
+      return new Extent(minX, minY, maxX, maxY)
+    } else if (Array.isArray(input) && input.length === 2) {
+      const [min, max] = input
+      return new Extent(min[0], min[1], max[0], max[1])
+    } else if (typeof input === "object" && input !== null) {
+      const { minX, minY, maxX, maxY } = input
+      return new Extent(minX, minY, maxX, maxY)
+    }
+
+    throw new Error("`input` argument must be of type `ExtentLike`")
+  }
+}
+
 export function extentForCoordinates(coordinates) {
   let minX = Infinity,
     minY = Infinity
@@ -34,7 +90,7 @@ export function combineExtents(extent1, extent2) {
  * Check if the passed coordinate is contained or on the edge of the extent.
  *
  * @param {Extent} extent Extent.
- * @param {import("./coordinate.js").Coordinate} coordinate Coordinate.
+ * @param {import("./coordinate").GeoCoordinateLike} coordinate Coordinate.
  * @return {boolean} The coordinate is contained in the extent.
  * @api
  */

--- a/src/lib/components/molecules/canvas-map/lib/util/extent.js
+++ b/src/lib/components/molecules/canvas-map/lib/util/extent.js
@@ -27,17 +27,37 @@ export class Extent {
   }
 
   /**
+   * Check if the passed coordinate is contained or on the edge of the extent.
+   *
+   * @param {[number, number]} coordinate Coordinate.
+   * @return {boolean} The coordinate is contained in the extent.
+   */
+  containsCoordinate(coordinate) {
+    return containsXY(this, coordinate[0], coordinate[1])
+  }
+
+  /**
+   * Combine with another extent
+   *
+   * @param {ExtentLike} extent
+   * @returns {Extent} A new extent that fits both this extent add the added one
+   */
+  combineWith(extent) {
+    return combineExtents(this, extent)
+  }
+
+  /**
    * Converts {@link ExtentLike} to an {@link Extent} object.
    *
    * If an {@link Extent} object is passed in, the function returns it unchanged.
    *
    *
    * @param {ExtentLike} input - Extent defined as {@link ExtentLike}.
-   * @returns A new `Extent` object, if a conversion occurred, or the original `Extent` object.
+   * @returns {Extent} A new `Extent` object, if a conversion occurred, or the original `Extent` object.
    */
   static convert(input) {
     if (input instanceof Extent) return input
-    if (!input) return input
+    if (!input) return null
 
     if (Array.isArray(input) && input.length === 4) {
       const [minX, minY, maxX, maxY] = input
@@ -54,6 +74,11 @@ export class Extent {
   }
 }
 
+/**
+ * Get extent for array of coordinates
+ * @param {[[number, number]]} coordinates
+ * @returns {Extent}
+ */
 export function extentForCoordinates(coordinates) {
   let minX = Infinity,
     minY = Infinity
@@ -75,26 +100,35 @@ export function extentForCoordinates(coordinates) {
     }
   }
 
-  return [minX, minY, maxX, maxY]
+  return new Extent(minX, minY, maxX, maxY)
 }
 
+/**
+ * Combine two extents into a single extent that contains both.
+ *
+ * @param {ExtentLike} extent1
+ * @param {ExtentLike} extent2
+ * @returns {Extent} The combined extent.
+ */
 export function combineExtents(extent1, extent2) {
-  const minX = Math.min(extent1[0], extent2[0])
-  const minY = Math.min(extent1[1], extent2[1])
-  const maxX = Math.max(extent1[2], extent2[2])
-  const maxY = Math.max(extent1[3], extent2[3])
-  return [minX, minY, maxX, maxY]
+  const e1 = Extent.convert(extent1)
+  const e2 = Extent.convert(extent2)
+
+  const minX = Math.min(e1.minX, e2.minX)
+  const minY = Math.min(e1.minY, e2.minY)
+  const maxX = Math.max(e1.maxX, e2.maxX)
+  const maxY = Math.max(e1.maxY, e2.maxY)
+
+  return new Extent(minX, minY, maxX, maxY)
 }
 
 /**
  * Check if the passed coordinate is contained or on the edge of the extent.
  *
  * @param {Extent} extent Extent.
- * @param {import("./coordinate").GeoCoordinateLike} coordinate Coordinate.
+ * @param {[number, number]} coordinate Coordinate.
  * @return {boolean} The coordinate is contained in the extent.
- * @api
  */
-
 export function containsCoordinate(extent, coordinate) {
   return containsXY(extent, coordinate[0], coordinate[1])
 }
@@ -106,8 +140,9 @@ export function containsCoordinate(extent, coordinate) {
  * @param {number} x X coordinate.
  * @param {number} y Y coordinate.
  * @return {boolean} The x, y values are contained in the extent.
- * @api
  */
 export function containsXY(extent, x, y) {
-  return extent[0] <= x && x <= extent[2] && extent[1] <= y && y <= extent[3]
+  return (
+    x >= extent.minX && x <= extent.maxX && y >= extent.minY && y <= extent.maxY
+  )
 }

--- a/src/lib/components/molecules/canvas-map/lib/util/index.js
+++ b/src/lib/components/molecules/canvas-map/lib/util/index.js
@@ -1,0 +1,6 @@
+export * from "./coordinate"
+export * from "./bounds"
+export * from "./extent"
+export * from "./bboxFeature"
+export * from "./resolution"
+export * from "./zoomLevel"

--- a/src/lib/components/molecules/canvas-map/map.stories.jsx
+++ b/src/lib/components/molecules/canvas-map/map.stories.jsx
@@ -21,6 +21,9 @@ import statesAlbers10mTopo from "./sample-data/states-albers-10m.json"
 import westminsterConstituenciesTopo from "./sample-data/uk-westminster-simplified.json"
 import usPresidentialResults from "./sample-data/us-presidential-results.json"
 import ukCitiesGeo from "./sample-data/uk-cities.json"
+import { useState, useCallback } from "preact/hooks"
+import { pointer } from "d3-selection"
+import { fn } from "@storybook/test"
 
 const meta = {
   title: "Molecules/Map",
@@ -112,12 +115,12 @@ export const USMap = {
     )
 
     return (
-      <Map {...args}>
+      <Map.Component {...args}>
         <VectorLayer.Component
           features={new GeoJSON().readFeaturesFromObject(filteredStates)}
           style={strokeStyle}
         />
-      </Map>
+      </Map.Component>
     )
   },
 }
@@ -152,12 +155,92 @@ export const USPreprojected = {
     const featureCollection = FeatureCollection.fromGeoJSON(states)
 
     return (
-      <Map {...args}>
+      <Map.Component {...args}>
         <VectorLayer.Component
           features={featureCollection}
           style={strokeStyle}
         />
-      </Map>
+      </Map.Component>
+    )
+  },
+}
+
+export const USInteractive = {
+  args: {
+    config: {
+      debug: true,
+      view: {
+        extent: [
+          [0, 0],
+          [975, 610],
+        ],
+        padding: { top: 0, right: 0, bottom: 0, left: 0 },
+      },
+    },
+    onHighlight: fn(),
+  },
+  render: ({ config, onHighlight }) => {
+    /** @type {[Map, function]} */
+    const [map, setMap] = useState()
+    const [highlightedFeature, setHiglightedFeature] = useState()
+
+    const states = feature(
+      // @ts-ignore
+      statesAlbers10mTopo,
+      statesAlbers10mTopo.objects["states"],
+    )
+
+    // @ts-ignore
+    const featureCollection = FeatureCollection.fromGeoJSON(states)
+
+    const onMouseMove = useCallback(
+      (event) => {
+        if (!map) return
+
+        // find feature under pointer
+        const features = map.findFeatures(pointer(event))
+
+        if (features.length > 0) {
+          setHiglightedFeature(features[0])
+          onHighlight(features[0].properties?.name)
+        }
+      },
+      [map, onHighlight],
+    )
+
+    const styleFeatures = useCallback(
+      (feature) => {
+        const stroke = new Stroke({
+          color: "#999",
+          width: 1,
+        })
+
+        if (feature === highlightedFeature) {
+          return new Style({
+            stroke,
+            fill: new Fill({ color: "#ededed" }),
+          })
+        }
+
+        return new Style({
+          stroke,
+        })
+      },
+      [highlightedFeature],
+    )
+
+    return (
+      <div
+        onMouseMove={onMouseMove}
+        style={{ position: "absolute", width: "100%", height: "100%" }}
+      >
+        <Map.Component config={config} onLoad={setMap}>
+          <VectorLayer.Component
+            features={featureCollection}
+            style={styleFeatures}
+          />
+        </Map.Component>
+      </div>
     )
   },
 }
@@ -184,7 +267,7 @@ export const USChoropleth = {
     const featureCollection = FeatureCollection.fromGeoJSON(states)
 
     return (
-      <Map config={config}>
+      <Map.Component config={config}>
         <VectorLayer.Component
           features={featureCollection}
           style={(feature) => {
@@ -192,7 +275,7 @@ export const USChoropleth = {
             return styleForResult(result)
           }}
         />
-      </Map>
+      </Map.Component>
     )
   },
 }
@@ -231,7 +314,7 @@ export const USElectoralCartogram = {
     )
 
     return (
-      <Map {...args}>
+      <Map.Component {...args}>
         <VectorLayer.Component
           features={cartogramFeatures}
           style={strokeStyle}
@@ -250,7 +333,7 @@ export const USElectoralCartogram = {
             })
           }}
         />
-      </Map>
+      </Map.Component>
     )
   },
 }
@@ -309,7 +392,7 @@ export const USSenateCartogram = {
 
     return (
       <div style={{ position: "absolute", width: "100%", height: "100%" }}>
-        <Map {...args}>
+        <Map.Component {...args}>
           <VectorLayer.Component features={stateFeatures} style={strokeStyle} />
           <VectorLayer.Component
             features={cartogramFeatures}
@@ -332,7 +415,7 @@ export const USSenateCartogram = {
             drawCollisionBoxes={false}
             style={textStyle}
           />
-        </Map>
+        </Map.Component>
       </div>
     )
   },
@@ -370,7 +453,7 @@ export const USHouseCartogram = {
     )
 
     return (
-      <Map {...args}>
+      <Map.Component {...args}>
         <VectorLayer.Component
           features={cartogramFeatures}
           style={strokeStyle}
@@ -389,7 +472,7 @@ export const USHouseCartogram = {
             })
           }}
         />
-      </Map>
+      </Map.Component>
     )
   },
 }
@@ -450,7 +533,7 @@ export const USGovernorsCartogram = {
 
     return (
       <div style={{ position: "absolute", width: "100%", height: "100%" }}>
-        <Map {...args}>
+        <Map.Component {...args}>
           <VectorLayer.Component features={stateFeatures} style={strokeStyle} />
           <VectorLayer.Component
             features={cartogramFeatures}
@@ -472,7 +555,7 @@ export const USGovernorsCartogram = {
             drawCollisionBoxes={false}
             style={textStyle}
           />
-        </Map>
+        </Map.Component>
       </div>
     )
   },
@@ -520,7 +603,7 @@ export const UKMap = {
     })
 
     return (
-      <Map {...args}>
+      <Map.Component {...args}>
         <VectorLayer.Component features={outlineFeatures} style={fillStyle} />
         <VectorLayer.Component
           features={constituenciesFeatures}
@@ -538,7 +621,7 @@ export const UKMap = {
             })
           }
         />
-      </Map>
+      </Map.Component>
     )
   },
 }

--- a/src/lib/shared/hooks/useTouchOrHover.js
+++ b/src/lib/shared/hooks/useTouchOrHover.js
@@ -1,8 +1,10 @@
+// @ts-nocheck
 import { useRef, useEffect, useState } from "preact/hooks"
 import { pointInsideRect } from "$shared/helpers/geometry"
 
 export function useTouchOrHover() {
   const ref = useRef()
+  const [activeEvent, setActiveEvent] = useState()
   const [position, setPosition] = useState()
   const [isActive, setIsActive] = useState(false)
   const [touchRect, setTouchRect] = useState()
@@ -31,7 +33,7 @@ export function useTouchOrHover() {
         height: touch.radiusY * 2,
       }
       setTouchRect(touchRect)
-
+      setActiveEvent(event)
       setIsActive(true)
 
       event.stopPropagation()
@@ -39,6 +41,7 @@ export function useTouchOrHover() {
 
     const touchMoved = (event) => {
       if (touchCancelled || event.targetTouches.length !== 1) return
+      setActiveEvent(event)
 
       const touch = event.targetTouches[0]
 
@@ -64,6 +67,7 @@ export function useTouchOrHover() {
         // prevent simulated click events
         event.preventDefault()
       }
+      setActiveEvent(null)
       setIsActive(false)
       setPosition(null)
     }
@@ -76,6 +80,7 @@ export function useTouchOrHover() {
       const y = clientY - rect.top
 
       setPosition({ x, y })
+      setActiveEvent(event)
       setIsActive(true)
     }
 
@@ -86,12 +91,14 @@ export function useTouchOrHover() {
       const x = clientX - rect.left
       const y = clientY - rect.top
 
+      setActiveEvent(event)
       setPosition({ x, y })
     }
 
     const mouseOut = () => {
-      setIsActive(false)
       setPosition(null)
+      setActiveEvent(null)
+      setIsActive(false)
     }
 
     element.addEventListener("touchstart", touchStarted)
@@ -120,5 +127,6 @@ export function useTouchOrHover() {
     touchOrHoverIsActive: isActive,
     touchRect,
     positionInTarget: position,
+    activeEvent,
   }
 }


### PR DESCRIPTION
The reason that hit detection broke for preprojected maps is that in various place in the Map component I implicitly made the assumption that map coordinates would always represent geographical coordinates (WGS84). This assumption obviously doesn't hold up when our map data has already been projected into screen coordinates.

The way I started untangling that mess is by making explicit types for different sets of coordinates, i.e. `Extent` vs `GeoBounds` and adding JSDoc types where relevant. This work is not entirely finished, but so far it seems to point to a direction where we can mostly express those values as `[x,y]` coordinates and `{minX, maxX, minY, maxY}` extents. We may  ultimately want to make it so that geographic coordinates `[lng, lat]` and bounds `{southWest, northEast}` are only exposed by the interface, whereas [x,y] coordinates are always used by the Map component internally.

Along the way I realised that to expose types for `Map.js` we needed to export it directly, rather than it being an internal class used by `Map.jsx`. From there it seemed logical to implement the same structure as we have for layers, i.e. `Map` is the VanillaJS map class, and the Preact component is defined as `Map.Component`.