### PR TITLE
Use Extent's new minX, minY, etc. properties in View.boundsForExtent

### DIFF
--- a/src/lib/components/molecules/canvas-map/lib/Map.js
+++ b/src/lib/components/molecules/canvas-map/lib/Map.js
@@ -165,8 +165,13 @@ export class Map {
     padding = { top: 40, right: 40, bottom: 40, left: 40 },
   ) {
     const extent = feature.getExtent()
-    const [[featureX, featureY], [featureWidth, featureHeight]] =
-      this.view.boundsForExtent(extent)
+
+    const {
+      minX: featureX,
+      minY: featureY,
+      width: featureWidth,
+      height: featureHeight,
+    } = this.view.projectExtent(extent)
     const [viewPortWidth, viewPortHeight] = this.view.viewPortSize
 
     const paddedViewPortWidth = viewPortWidth - padding.left - padding.right

--- a/src/lib/components/molecules/canvas-map/lib/View.js
+++ b/src/lib/components/molecules/canvas-map/lib/View.js
@@ -140,7 +140,6 @@ export class View {
   }
 
   /**
-   *
    * @param {import("./formats/GeoJSON").GeoJSONFeature} geoJSON
    */
   fitObject(geoJSON) {
@@ -151,10 +150,14 @@ export class View {
     ++this.projection.revision
   }
 
-  // returns bounds relative to the viewport
+  /**
+   * Returns bounds relative to the viewport
+   *
+   * @param {import("./util/extent").Extent} extent
+   */
   boundsForExtent(extent) {
-    const SW = this.projection([extent[0], extent[1]])
-    const NE = this.projection([extent[2], extent[3]])
+    const SW = this.projection([extent.minX, extent.minY])
+    const NE = this.projection([extent.maxX, extent.maxY])
     const minX = SW[0] / this.pixelRatio
     const minY = NE[1] / this.pixelRatio
     const maxX = NE[0] / this.pixelRatio

--- a/src/lib/components/molecules/canvas-map/lib/View.js
+++ b/src/lib/components/molecules/canvas-map/lib/View.js
@@ -100,7 +100,10 @@ export class View {
     return baseResolution
   }
 
-  // calculates the upper and lower zoom scales
+  /**
+   * Get the lower and upper zoom scales
+   * @returns {[number, number]} - The lower and upper zoom scales
+   */
   get scaleExtent() {
     const maxScale = zoomLevelToZoomScale(this.maxZoom, this.baseResolution)
     return [1, maxScale]
@@ -151,23 +154,16 @@ export class View {
   }
 
   /**
-   * Returns bounds relative to the viewport
+   * Returns extent in projection coordinates
    *
-   * @param {import("./util/extent").Extent} extent
+   * @param {Extent} extent
+   * @returns {Extent} - The extent relative to the current viewport
    */
-  boundsForExtent(extent) {
-    const SW = this.projection([extent.minX, extent.minY])
-    const NE = this.projection([extent.maxX, extent.maxY])
-    const minX = SW[0] / this.pixelRatio
-    const minY = NE[1] / this.pixelRatio
-    const maxX = NE[0] / this.pixelRatio
-    const maxY = SW[1] / this.pixelRatio
-    const width = maxX - minX
-    const height = maxY - minY
-    return [
-      [minX, minY],
-      [width, height],
-    ]
+
+  projectExtent(extent) {
+    const [minX, minY] = this.projection([extent.minX, extent.minY])
+    const [maxX, maxY] = this.projection([extent.maxX, extent.maxY])
+    return new Extent(minX, minY, maxX, maxY).scale(1 / this.pixelRatio)
   }
 
   invert(point) {

--- a/src/lib/components/molecules/canvas-map/lib/util/extent.js
+++ b/src/lib/components/molecules/canvas-map/lib/util/extent.js
@@ -22,8 +22,34 @@ export class Extent {
     this.maxY = maxY
   }
 
+  get width() {
+    return this.maxX - this.minX
+  }
+
+  get height() {
+    return this.maxY - this.minY
+  }
+
+  /**
+   * Turn extent into a flat array of numbers: [minX, minY, maxX, maxY].
+   *
+   * @returns {[number, number, number, number]} - The extent as a flat array
+   */
   flat() {
     return [this.minX, this.minY, this.maxX, this.maxY]
+  }
+
+  /**
+   * Create a new extent where the coordinates are multiplied by scaleFactor.
+   *
+   * @param {number} scaleFactor
+   * @returns {Extent} - The scaled
+   */
+  scale(scaleFactor) {
+    const scaled = /** @type {ExtentLike} */ (
+      [this.minX, this.minY, this.maxX, this.maxY].map((d) => d * scaleFactor)
+    )
+    return Extent.convert(scaled)
   }
 
   /**

--- a/src/lib/components/molecules/canvas-map/map.stories.jsx
+++ b/src/lib/components/molecules/canvas-map/map.stories.jsx
@@ -208,6 +208,18 @@ export const USInteractiveMap = {
       [map, onHighlight],
     )
 
+    const onClick = useCallback(
+      (event) => {
+        if (!map) return
+
+        const features = map.findFeatures(pointer(event))
+        if (features.length > 0) {
+          map.zoomToFeature(features[0])
+        }
+      },
+      [map],
+    )
+
     const styleFeatures = useCallback(
       (featureToStyle) => {
         const stroke = new Stroke({
@@ -232,6 +244,7 @@ export const USInteractiveMap = {
     return (
       <div
         onMouseMove={onMouseMove}
+        onClick={onClick}
         style={{ position: "absolute", width: "100%", height: "100%" }}
       >
         <Map.Component config={config} onLoad={setMap}>


### PR DESCRIPTION
This PR fixes a small bug in the `View` class' `boundsForExtent` method, which assumes its `extent` parameter is a 4-tuple 
(which it presumably was until f787b36742ef6862cba16ed7f40d165b97cb872e), when it's actually an `Extent` instance.

At least, this is what I've observed when using the Map component (see the screenshots below) - please let me know if there's a chance that this `extent` parameter could be an `Extent` _or_ a 4-tuple.

<img width="600" src="https://github.com/user-attachments/assets/ff320173-6c2c-4116-929d-93954677dfa4">

<img src="https://github.com/user-attachments/assets/7d78de73-6db2-4959-a3b0-4bac265e6fa6" width=600>
