### PR TITLE
Fix map component ref

### DIFF
--- a/src/lib/components/molecules/canvas-map/Map.jsx
+++ b/src/lib/components/molecules/canvas-map/Map.jsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useRef } from "preact/hooks"
-import { forwardRef } from "preact/compat"
 import { Map } from "./lib/Map"
 import { MapProvider } from "./context/MapContext"
 // @ts-ignore
@@ -13,113 +12,115 @@ const mobileHelpText = "Use two fingers to zoom"
  *    inModalState?: boolean,
  *    onLoad?: (map: Map) => void,
  *    children: import('preact').ComponentChildren,
+ *    mapRef?: import('preact').Ref<Map>
  * }} MapComponentProps
  */
 
-Map.Component = forwardRef(
-  (
-    /** @type {MapComponentProps} */ {
-      config,
-      inModalState = false,
-      onLoad,
-      children,
-    },
-    ref,
-  ) => {
-    const targetRef = useRef()
-
-    const [map, setMap] = useState(/** @type {Map | null} */ (null))
-    const [zoomHelpText, setZoomHelpText] = useState("")
-    const [showHelpText, setShowHelpText] = useState(false)
-
-    useEffect(() => {
-      if (!targetRef.current) return
-
-      const map = new Map({
-        ...config,
-        target: targetRef.current,
-      })
-
-      map.collaborativeGesturesEnabled(true)
-      setMap(map)
-
-      if (ref) {
-        // @ts-ignore
-        ref.current = map
-      }
-
-      if (onLoad) {
-        onLoad(map)
-      }
-
-      let zoomHelpText = ""
-      if (
-        // @ts-ignore
-        navigator.userAgentData?.mobile ||
-        navigator.userAgent.indexOf("Mobile") !== -1
-      ) {
-        zoomHelpText = mobileHelpText
-      } else {
-        zoomHelpText =
-          navigator.userAgent.indexOf("Mac") !== -1
-            ? "Use ⌘ + scroll to zoom"
-            : "Use Ctrl + scroll to zoom"
-      }
-      setZoomHelpText(zoomHelpText)
-
-      return () => {
-        map.destroy()
-        setMap(null)
-
-        if (ref) {
-          // @ts-ignore
-          ref.current = null
-        }
-      }
-    }, [config, onLoad, ref])
-
-    useEffect(() => {
-      if (!map) return
-      let timeoutID
-
-      map.onFilterEvent((showHelpText) => {
-        if (timeoutID) clearTimeout(timeoutID)
-
-        setShowHelpText(showHelpText)
-
-        if (showHelpText) {
-          timeoutID = setTimeout(() => {
-            setShowHelpText(false)
-          }, 1000)
-        }
-      })
-
-      return () => {
-        if (timeoutID) clearTimeout(timeoutID)
-      }
-    }, [map])
-
-    useEffect(() => {
-      if (!map) return
-      map.collaborativeGesturesEnabled(!inModalState)
-    }, [map, inModalState])
-
-    return (
-      <figure ref={targetRef} className={styles.mapContainer}>
-        <div
-          className={styles.helpTextContainer}
-          style={{ opacity: showHelpText ? 1 : 0 }}
-          aria-hidden
-        >
-          <p className={[styles.helpText, styles.desktopHelpText].join(" ")}>
-            {zoomHelpText}
-          </p>
-          <p className={[styles.helpText, styles.mobileHelpText].join(" ")}>
-            {mobileHelpText}
-          </p>
-        </div>
-        <MapProvider map={map}>{children}</MapProvider>
-      </figure>
-    )
+const Component = (
+  /** @type {MapComponentProps} */ {
+    config,
+    inModalState = false,
+    onLoad,
+    children,
+    mapRef,
   },
-)
+) => {
+  const targetRef = useRef()
+
+  const [map, setMap] = useState(/** @type {Map | null} */ (null))
+  const [zoomHelpText, setZoomHelpText] = useState("")
+  const [showHelpText, setShowHelpText] = useState(false)
+
+  useEffect(() => {
+    if (!targetRef.current) return
+
+    const map = new Map({
+      ...config,
+      target: targetRef.current,
+    })
+
+    map.collaborativeGesturesEnabled(true)
+    setMap(map)
+
+    if (mapRef) {
+      // @ts-ignore
+      mapRef.current = map
+    }
+
+    if (onLoad) {
+      onLoad(map)
+    }
+
+    let zoomHelpText = ""
+    if (
+      // @ts-ignore
+      navigator.userAgentData?.mobile ||
+      navigator.userAgent.indexOf("Mobile") !== -1
+    ) {
+      zoomHelpText = mobileHelpText
+    } else {
+      zoomHelpText =
+        navigator.userAgent.indexOf("Mac") !== -1
+          ? "Use ⌘ + scroll to zoom"
+          : "Use Ctrl + scroll to zoom"
+    }
+    setZoomHelpText(zoomHelpText)
+
+    return () => {
+      map.destroy()
+      setMap(null)
+
+      if (mapRef) {
+        // @ts-ignore
+        mapRef.current = null
+      }
+    }
+  }, [config, onLoad, mapRef])
+
+  useEffect(() => {
+    if (!map) return
+    let timeoutID
+
+    map.onFilterEvent((showHelpText) => {
+      if (timeoutID) clearTimeout(timeoutID)
+
+      setShowHelpText(showHelpText)
+
+      if (showHelpText) {
+        timeoutID = setTimeout(() => {
+          setShowHelpText(false)
+        }, 1000)
+      }
+    })
+
+    return () => {
+      if (timeoutID) clearTimeout(timeoutID)
+    }
+  }, [map])
+
+  useEffect(() => {
+    if (!map) return
+    map.collaborativeGesturesEnabled(!inModalState)
+  }, [map, inModalState])
+
+  return (
+    <figure ref={targetRef} className={styles.mapContainer}>
+      <div
+        className={styles.helpTextContainer}
+        style={{ opacity: showHelpText ? 1 : 0 }}
+        aria-hidden
+      >
+        <p className={[styles.helpText, styles.desktopHelpText].join(" ")}>
+          {zoomHelpText}
+        </p>
+        <p className={[styles.helpText, styles.mobileHelpText].join(" ")}>
+          {mobileHelpText}
+        </p>
+      </div>
+      <MapProvider map={map}>{children}</MapProvider>
+    </figure>
+  )
+}
+
+// NOTE: we declare Component separately so the component has a "display name"
+Map.Component = Component


### PR DESCRIPTION
Using a custom prop name (`mapRef`) vs `ref` seems to solve this problem.

I guess Preact is keen to set `ref` itself, as it is a "special" prop name? And really, we shouldn't be overriding `ref` and have it point to something that isn't an element reference.