### PR TITLE
Use new Extent class in Point

### DIFF
--- a/src/lib/components/molecules/canvas-map/lib/geometry/Point.js
+++ b/src/lib/components/molecules/canvas-map/lib/geometry/Point.js
@@ -1,9 +1,15 @@
+import { Extent } from "../util"
 import { Geometry } from "./Geometry"
 
 export class Point extends Geometry {
   constructor({ type = "Point", coordinates }) {
     super({ type, extent: null, coordinates })
-    this.extent = [...coordinates, ...coordinates]
+    this.extent = new Extent(
+      coordinates[0],
+      coordinates[1],
+      coordinates[0],
+      coordinates[1],
+    )
   }
 
   _getProjected(projection) {


### PR DESCRIPTION
Looks like we forgot to update this Point class along with the others in the recent preprojected geography fixes (c07c124), in which we changed from expressing _extents_ as 4-length arrays (e.g. `[2,4,7,2]`) to a proper `Extent` class, which internally expresses them as `{ minX: 2, minY: 4, maxX: 7, maxY: 2 }`.

This fixes the missing text issue in the canvas map stories...

<img src="https://github.com/user-attachments/assets/09fb6e03-8384-4aa0-9d63-d7c7c83385ca">

