### PR TITLE
Control change: switch text field to take html 

### DIFF
--- a/src/lib/components/molecules/control-change/control-change.stories.jsx
+++ b/src/lib/components/molecules/control-change/control-change.stories.jsx
@@ -14,7 +14,7 @@ const hasChangedArgs = {
 const hasChangedAlt = {
   previous: "snp",
   next: "lab",
-  text: "Lab gain from SNP",
+  text: `Lab gain from SNP, <span style='font-weight: 500'>a key seat</span>`,
 }
 
 const hasChangedAlt2 = {

--- a/src/lib/components/molecules/control-change/index.jsx
+++ b/src/lib/components/molecules/control-change/index.jsx
@@ -21,7 +21,10 @@ export const ControlChange = ({ previous, next, text, styles }) => {
       ) : (
         <CircleIcon styles={{ circle: `fill-color--${next}` }} />
       )}
-      <strong className={styles.text}>{text}</strong>
+      <span
+        className={styles.text}
+        dangerouslySetInnerHTML={{ __html: text }}
+      ></span>
     </div>
   )
 }


### PR DESCRIPTION
Aware that we prefer _not_ to use `dangerouslySetInnerHTML` but.... 

The US election design calls for this line to take differential styling - ie some of the text in the line is in bold and some is not. To achieve that, you need to wrap the relevant text in a span. 

To accept a span without just printing out `<span>a key swing state </span>`, the component needs to accept html rather than just text. 

<img width="405" alt="Screenshot 2024-09-05 at 17 19 14" src="https://github.com/user-attachments/assets/b790e082-a320-47d3-a347-b884804ad926">


