### PR TITLE
Add splitColor prop to CircleIcon

### DIFF
--- a/src/lib/components/particles/circle-icon/circle-icon.stories.jsx
+++ b/src/lib/components/particles/circle-icon/circle-icon.stories.jsx
@@ -18,3 +18,11 @@ export const Pulse = {
     pulse: true,
   },
 }
+
+export const Split = {
+  args: {
+    diameter: 20,
+    color: "var(--news-core-03)",
+    splitColor: "var(--news-core-02)",
+  },
+}

--- a/src/lib/components/particles/circle-icon/index.jsx
+++ b/src/lib/components/particles/circle-icon/index.jsx
@@ -1,7 +1,21 @@
 import defaultStyles from "./style.module.css"
 import { mergeStyles } from "$styles/helpers/mergeStyles"
 
-export const CircleIcon = ({ color, pulse = false, diameter = 11, styles }) => {
+/**
+ * @typedef {Object} CircleIconProps
+ * @property {string} color
+ * @property {boolean} [pulse]
+ * @property {number} [diameter=11]
+ * @property {string} [splitColor]
+ * @property {Object} [styles]
+ */
+export const CircleIcon = ({
+  color,
+  pulse = false,
+  diameter = 11,
+  styles,
+  splitColor,
+}) => {
   styles = mergeStyles(defaultStyles, styles)
 
   let radius = diameter / 2
@@ -23,6 +37,13 @@ export const CircleIcon = ({ color, pulse = false, diameter = 11, styles }) => {
         cx={radius + padding / 2}
         cy={radius + padding / 2}
       />
+      {splitColor && (
+        <path
+          d={`M ${radius + padding / 2} ${padding / 2} A ${radius} ${radius} 0 0 1 ${radius + padding / 2} ${diameter + padding / 2} L ${radius + padding / 2} ${radius + padding / 2} Z`}
+          fill={splitColor}
+          transform={`rotate(45 ${radius + padding / 2} ${radius + padding / 2})`}
+        />
+      )}
     </svg>
   )
 }


### PR DESCRIPTION
This PR adds a new `splitColor` prop to the `CircleIcon` component, letting us draw half-and-half SVG circles, like this! ✨ 

<img width="500" alt="image" src="https://github.com/user-attachments/assets/ab7e48eb-b74c-4b84-ac4b-f8f2cf116d85">