### PR TITLE
Fix CircleIcon styles prop

### DIFF
--- a/src/lib/components/particles/circle-icon/index.jsx
+++ b/src/lib/components/particles/circle-icon/index.jsx
@@ -23,7 +23,7 @@ export const CircleIcon = ({
 
   return (
     <svg
-      style={styles.svg}
+      className={styles.svg}
       fill="none"
       height={diameter + padding}
       viewBox={`0 0 ${diameter + padding} ${diameter + padding}`}


### PR DESCRIPTION
Tiny fix to the `CircleIcon` component that'll let us use its `styles` prop properly (🥁).

I've checked for usages of this styles.svg property across our codebases and this won't break anything - it isn't used anywhere!