### PR TITLE
Fix TextLayer decluttering, fix OptionPicker item sizing

### DIFF
--- a/src/lib/components/molecules/canvas-map/lib/renderers/MapRenderer.js
+++ b/src/lib/components/molecules/canvas-map/lib/renderers/MapRenderer.js
@@ -49,18 +49,14 @@ export class MapRenderer {
       viewState.projection = projection
     }
 
-    const baseLayers = visibleLayers.filter((layer) => !layer.declutter)
-    for (const layer of baseLayers) {
-      renderLayer(layer)
-    }
-
     const declutterTree = new RBush()
 
-    const layersToDeclutter = [...visibleLayers]
-      .filter((layer) => !!layer.declutter)
-      .reverse()
-    for (const layer of layersToDeclutter) {
-      renderLayer(layer, declutterTree)
+    for (const layer of visibleLayers) {
+      if (layer.declutter) {
+        renderLayer(layer, declutterTree)
+      } else {
+        renderLayer(layer)
+      }
     }
 
     replaceChildren(this._element, mapElements)

--- a/src/lib/components/molecules/canvas-map/lib/renderers/TextLayerRenderer.js
+++ b/src/lib/components/molecules/canvas-map/lib/renderers/TextLayerRenderer.js
@@ -66,12 +66,15 @@ export class TextLayerRenderer {
         x: relativeX * viewPortSize[0],
         y: relativeY * viewPortSize[1],
       })
-      if (declutterTree.collides(bbox)) {
-        continue
-      }
 
-      // add element to declutter tree to prevent collisions
-      declutterTree.insert(bbox)
+      if (declutterTree) {
+        if (declutterTree.collides(bbox)) {
+          continue
+        }
+
+        // add element to declutter tree to prevent collisions
+        declutterTree.insert(bbox)
+      }
 
       if (this.layer.drawCollisionBoxes) {
         const collisionBoxDebugElement = this.getCollisionBoxElement(bbox)

--- a/src/lib/components/molecules/option-picker/style.module.css
+++ b/src/lib/components/molecules/option-picker/style.module.css
@@ -29,12 +29,13 @@
 }
 
 .option {
+  flex: 1;
+
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: var(--space-2);
   min-height: 70px;
-  max-width: 124px;
 
   border: 1px solid var(--border-divider-color);
   border-radius: 8px;


### PR DESCRIPTION
This PR fixes an issue with the canvas map's `TextLayer` component, that appears when trying to set the `declutter` prop to false.

It also tweaks the option picker to make its appearance a bit more predictable and balanced.

## `TextLayer` declutter fixes

This change makes sure to null check `declutterTree` in `TextLayerRenderer`, which will be null when creating a `TextLayer` with declutter=false. Without this, the map just crashes when this prop is set to false.

It also makes sure to draw declutter=true and declutter=false layers in order, rather than "all declutter=false first, then all declutter=true".

## `OptionPicker` changes

This fix removes the maximum item width, so the items fill the container regardless of its size. It also ensures that, by default, items are evenly-sized in the container.

| Before | After |
| - | - |
| <img width="400" src="https://github.com/user-attachments/assets/7a3da19b-a727-4eeb-99d1-a496cc5ad86c"> | <img width="400" src="https://github.com/user-attachments/assets/1a7f242b-8fb3-44ad-9d23-9d69759159bb"> |
| <img width="400" src="https://github.com/user-attachments/assets/6cd5874f-4e09-41fd-bcd9-a1a239ea0d9a"> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/d768ac6e-ff94-4e1d-86ea-307245a98ac1"> |