### PR TITLE
Ticker CSS tweak: allow horiz scroll even behind gradient

### DIFF
--- a/src/lib/components/organisms/ticker/style.module.scss
+++ b/src/lib/components/organisms/ticker/style.module.scss
@@ -14,6 +14,7 @@
   position: relative;
   --ticker-item-width: 200px;
   padding: 0;
+  cursor: default;
 }
 
 .tickerItems {
@@ -90,6 +91,7 @@
   }
 }
 .gradientHorizontal {
+  pointer-events: none;
   width: 60px;
   height: 100%;
   right: 0;


### PR DESCRIPTION
The overlay gradient was blocking scroll events at the right-hand end of the ticker. 

This stops the gradient div capturing pointer events so that the whole ticker bar is scrollable 

fixed:

https://github.com/user-attachments/assets/33234d99-e0b4-435f-924d-7ab35534a8d7


