### PR TITLE
Add 'pointRadius' to 'Style' class

### DIFF
--- a/src/lib/components/molecules/canvas-map/lib/renderers/FeatureRenderer.js
+++ b/src/lib/components/molecules/canvas-map/lib/renderers/FeatureRenderer.js
@@ -24,9 +24,11 @@ export class FeatureRenderer {
     const feature = this.feature
 
     const { projection, transform, pixelRatio } = frameState.viewState
-    const { stroke, fill } = this.style
+
+    const { stroke, fill, pointRadius } = this.style
 
     const geometries = feature.getProjectedGeometries(projection)
+
     if (frameState.debug) {
       try {
         validateGeometries(geometries)
@@ -37,6 +39,13 @@ export class FeatureRenderer {
         )
       }
     }
+
+    if (pointRadius) {
+      this.drawingFunction.pointRadius(
+        (projection.scale() * pointRadius) / transform.k,
+      )
+    }
+
     this.drawPath(geometries, context)
 
     if (fill) {
@@ -58,6 +67,7 @@ export class FeatureRenderer {
     this.drawingFunction.context(context)
 
     context.beginPath()
+
     for (const geometry of geometries) {
       this.drawingFunction(geometry)
     }

--- a/src/lib/components/molecules/canvas-map/lib/styles/Style.js
+++ b/src/lib/components/molecules/canvas-map/lib/styles/Style.js
@@ -11,12 +11,14 @@
  * @property {Object} properties.stroke - The stroke color of the style
  * @property {Fill} properties.fill - The fill color of the style
  * @property {Object} properties.text - The text color of the style
+ * @property {number} properties.pointRadius - Radius of drawn "Point"-type geometries, if present
  */
 export class Style {
   constructor(properties) {
     this.stroke = properties?.stroke
     this.fill = properties?.fill
     this.text = properties?.text
+    this.pointRadius = properties?.pointRadius
   }
 
   clone() {
@@ -24,6 +26,7 @@ export class Style {
       stroke: this.stroke,
       fill: this.fill,
       text: this.text,
+      pointRadius: this.pointRadius,
     })
   }
 }

--- a/src/lib/components/particles/relative-time-sentence/index.jsx
+++ b/src/lib/components/particles/relative-time-sentence/index.jsx
@@ -1,7 +1,7 @@
 import defaultStyles from "./style.module.css"
 import { mergeStyles } from "$styles/helpers/mergeStyles.js"
 import dayjs from "dayjs"
-import relativeTime from "dayjs/plugin/relativeTime"
+import relativeTime from "dayjs/plugin/relativeTime.js"
 dayjs.extend(relativeTime)
 
 export const RelativeTimeSentence = ({ timeStamp, styles }) => {


### PR DESCRIPTION
This PR adds a `pointRadius` property to the `Style` class, that lets us control the radius of the "Point"-type geometries,
drawn by the underlying d3-geo drawing functions.

This uses [the pointRadius function exposed by d3's path generator](https://d3js.org/d3-geo/path#path_pointRadius).

Now, when drawing "Point"-type map features, we can use a `Style` instance like so...

```js
return new Style({
  pointRadius: 50,
  fill: new Fill({
    color: "#ff0000"
  }),
})
```