### PR TITLE
Fix canvas map component hierarchy sync

### DIFF
--- a/src/lib/components/molecules/canvas-map/lib/layers/TextLayer.js
+++ b/src/lib/components/molecules/canvas-map/lib/layers/TextLayer.js
@@ -144,3 +144,6 @@ export class TextLayer {
     return this.renderer.renderFrame(frameState, targetElement)
   }
 }
+
+// Set displayName so we don't just see "Component" in React DevTools
+TextLayer.Component.displayName = "TextLayer"

--- a/src/lib/components/molecules/canvas-map/lib/layers/VectorLayer.js
+++ b/src/lib/components/molecules/canvas-map/lib/layers/VectorLayer.js
@@ -166,3 +166,6 @@ export class VectorLayer {
     return this.renderer.renderFrame(frameState, targetElement)
   }
 }
+
+// Set displayName so we don't just see "Component" in React DevTools
+VectorLayer.Component.displayName = "VectorLayer"


### PR DESCRIPTION
This change fixes a subtle bug in the code that synchronises our React component hierarchy (of VectorLayer and TextLayer components) with the layers that are rendered on the map.

It also adds some debug code to this function, to help with future troubleshooting.