### PR TITLE
Add callouts and icons to `TextLayer`

### DIFF
--- a/src/lib/components/molecules/canvas-map/lib/Feature.js
+++ b/src/lib/components/molecules/canvas-map/lib/Feature.js
@@ -62,6 +62,9 @@ export class Feature {
     return this._getProjectedGeometries(projection, projection.revision)
   }
 
+  /**
+   * @returns {import("./styles/Style").StyleFunction}
+   */
   getStyleFunction() {
     const style = this.style
     if (!style) return null

--- a/src/lib/components/molecules/canvas-map/lib/layers/TextLayer.js
+++ b/src/lib/components/molecules/canvas-map/lib/layers/TextLayer.js
@@ -90,13 +90,46 @@ export class TextLayer {
     declutter = true,
     drawCollisionBoxes = false,
   }) {
+    // NOTE: unfortunately JSDoc isn't smart enough to infer class property types, so we have to
+    // declare the types like so
+    /**
+     * @type {VectorSource}
+     * @public
+     */
     this.source = source
+    /**
+     * @type {Style|import("../styles").StyleFunction}
+     */
     this._style = style
+    /**
+     * @type {number}
+     * @public
+     */
     this.minZoom = minZoom
+    /**
+     * @type {number}
+     * @public
+     */
     this.opacity = opacity
+    /**
+     * @type {boolean}
+     * @public
+     */
     this.declutter = declutter
+    /**
+     * @type {boolean}
+     * @public
+     */
     this.drawCollisionBoxes = drawCollisionBoxes
+    /**
+     * @type {TextLayerRenderer}
+     * @public
+     */
     this.renderer = new TextLayerRenderer(this)
+    /**
+     * @type {Dispatcher}
+     * @public
+     */
     this.dispatcher = new Dispatcher(this)
   }
 
@@ -132,6 +165,9 @@ export class TextLayer {
     return extent
   }
 
+  /**
+   * @returns {import("../styles/Style").StyleFunction}
+   */
   getStyleFunction() {
     const style = this.style
     if (typeof style === "function") return style

--- a/src/lib/components/molecules/canvas-map/lib/layers/TextLayer.js
+++ b/src/lib/components/molecules/canvas-map/lib/layers/TextLayer.js
@@ -60,7 +60,7 @@ export class TextLayer {
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [style])
 
-    return false
+    return null
   }
 
   /**

--- a/src/lib/components/molecules/canvas-map/lib/layers/VectorLayer.js
+++ b/src/lib/components/molecules/canvas-map/lib/layers/VectorLayer.js
@@ -84,16 +84,46 @@ export class VectorLayer {
     opacity = 1,
     hitDetectionEnabled = true,
   }) {
-    this.dispatcher = new Dispatcher(this)
-    this.renderer = new VectorLayerRenderer(this)
+    // NOTE: unfortunately JSDoc isn't smart enough to infer class property types, so we have to
+    // declare the types like so
+    /**
+     * @type {VectorSource}
+     * @public
+     */
     this.source = source
-    this._style = style
+    /**
+     * @type {Dispatcher}
+     * @public
+     */
+    this.dispatcher = new Dispatcher(this)
+    /**
+     * @type {VectorLayerRenderer}
+     * @public
+     */
+    this.renderer = new VectorLayerRenderer(this)
+    /**
+     * @type {number}
+     * @public
+     */
     this.minZoom = minZoom
+    /**
+     * @type {number}
+     * @public
+     */
     this.opacity = opacity
+    /**
+     * @type {boolean}
+     * @public
+     */
     this.hitDetectionEnabled = hitDetectionEnabled
+    /**
+     * @type {Style|import("../styles").StyleFunction}
+     */
+    this._style = style
   }
 
   get source() {
+    // TODO: should this be this.source, as per constructor?
     return this._source
   }
 
@@ -132,6 +162,9 @@ export class VectorLayer {
     this.dispatcher.dispatch(MapEvent.CHANGE)
   }
 
+  /**
+   * @returns {import("../styles/Style").StyleFunction}
+   */
   getStyleFunction() {
     const style = this.style
     if (typeof style === "function") return style

--- a/src/lib/components/molecules/canvas-map/lib/layers/VectorLayer.js
+++ b/src/lib/components/molecules/canvas-map/lib/layers/VectorLayer.js
@@ -57,7 +57,7 @@ export class VectorLayer {
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [style])
 
-    return false
+    return null
   }
 
   /**

--- a/src/lib/components/molecules/canvas-map/lib/renderers/FeatureRenderer.js
+++ b/src/lib/components/molecules/canvas-map/lib/renderers/FeatureRenderer.js
@@ -54,11 +54,13 @@ export class FeatureRenderer {
 
     if (stroke) {
       context.save()
+
       this.drawStroke(frameState, context, {
         style: stroke.getRgba(),
         width: (stroke.width / transform.k) * pixelRatio,
         position: stroke.position,
       })
+
       context.restore()
     }
   }

--- a/src/lib/components/molecules/canvas-map/lib/renderers/MapRenderer.js
+++ b/src/lib/components/molecules/canvas-map/lib/renderers/MapRenderer.js
@@ -31,6 +31,7 @@ export class MapRenderer {
 
     const renderLayer = (layer, declutterTree) => {
       const viewState = frameState.viewState
+
       // set layer projection if applicable
       if (layer.projection) {
         viewState.projection = layer.projection
@@ -40,6 +41,7 @@ export class MapRenderer {
         { ...frameState, viewState, declutterTree },
         previousElement,
       )
+
       if (element !== previousElement) {
         mapElements.push(element)
         previousElement = element

--- a/src/lib/components/molecules/canvas-map/lib/renderers/MapRenderer.js
+++ b/src/lib/components/molecules/canvas-map/lib/renderers/MapRenderer.js
@@ -1,6 +1,15 @@
 import { replaceChildren } from "../util/dom"
 import RBush from "rbush"
 
+/**
+ * @typedef {Object} CanvasSingleton
+ * @property {() => CanvasRenderingContext2D} getContext2d
+ * @property {() => HTMLDivElement} getContainer
+ * @property {() => boolean} isInitialised
+ *
+ * @typedef {Object} FrameState
+ */
+
 export class MapRenderer {
   constructor(map) {
     this.map = map
@@ -18,33 +27,37 @@ export class MapRenderer {
   }
 
   renderFrame(frameState) {
-    const { zoomLevel, projection } = frameState.viewState
+    const { zoomLevel, projection, sizeInPixels } = frameState.viewState
 
     const layers = this.map.layers
 
     const mapElements = []
-    let previousElement = null
 
     const visibleLayers = layers.filter((layer) => {
       return zoomLevel > (layer.minZoom || 0)
     })
 
+    const canvasSingleton = makeCanvasSingleton(sizeInPixels)
+
     const renderLayer = (layer, declutterTree) => {
       const viewState = frameState.viewState
 
-      // set layer projection if applicable
       if (layer.projection) {
         viewState.projection = layer.projection
       }
 
-      const element = layer.renderFrame(
+      // Render the layer, providing the canvas singleton in case this layer wants to render our
+      // canvas singleton
+      const newContainer = layer.renderFrame(
         { ...frameState, viewState, declutterTree },
-        previousElement,
+        canvasSingleton,
       )
 
-      if (element !== previousElement) {
-        mapElements.push(element)
-        previousElement = element
+      // If renderFrame created a new element, add it to the list of elements we add to the map
+      // container. This is currently only used for the TextLayer, each of which puts its layers in
+      // a new div.
+      if (newContainer) {
+        mapElements.push(newContainer)
       }
 
       // reset to map projection
@@ -61,6 +74,71 @@ export class MapRenderer {
       }
     }
 
-    replaceChildren(this._element, mapElements)
+    if (canvasSingleton.isInitialised()) {
+      // If canvas was used by any layer, add it to the map container, beneath all other elements so
+      // they're not occluded
+      replaceChildren(this._element, [
+        canvasSingleton.getContainer(),
+        ...mapElements,
+      ])
+    } else {
+      replaceChildren(this._element, mapElements)
+    }
   }
+}
+
+/**
+ * @param {[number, number]} sizeInPixels
+ * @returns {CanvasSingleton}
+ */
+function makeCanvasSingleton(sizeInPixels) {
+  /** @type {HTMLDivElement} */
+  let canvasLayer
+  let canvasContext2d
+
+  return {
+    getContext2d: () => {
+      if (!canvasLayer) {
+        canvasLayer = createCanvasMapLayer(sizeInPixels)
+        canvasContext2d = canvasLayer.firstElementChild.getContext("2d")
+      }
+
+      return canvasContext2d
+    },
+    getContainer: () => {
+      if (!canvasLayer) {
+        canvasLayer = createCanvasMapLayer(sizeInPixels)
+        canvasContext2d = canvasLayer.firstElementChild.getContext("2d")
+      }
+
+      return canvasLayer
+    },
+    isInitialised: () => !!canvasLayer,
+  }
+}
+
+/**
+ * @param {[number, number]} sizeInPixels
+ */
+function createCanvasMapLayer(sizeInPixels) {
+  const container = document.createElement("div")
+  container.className = "gv-map-layer"
+
+  let style = container.style
+  style.position = "absolute"
+  style.width = "100%"
+  style.height = "100%"
+
+  const canvas = document.createElement("canvas")
+  style = canvas.style
+  style.position = "absolute"
+  style.width = "100%"
+  style.height = "100%"
+
+  canvas.width = sizeInPixels[0]
+  canvas.height = sizeInPixels[1]
+
+  container.appendChild(canvas)
+
+  return container
 }

--- a/src/lib/components/molecules/canvas-map/lib/renderers/TextLayerRenderer.js
+++ b/src/lib/components/molecules/canvas-map/lib/renderers/TextLayerRenderer.js
@@ -22,8 +22,11 @@ export class TextLayerRenderer {
     style.overflow = "hidden"
   }
 
-  renderFrame(frameState, targetElement) {
-    if (this.layer.opacity === 0) return targetElement
+  /**
+   * @param {import("./MapRenderer").CanvasSingleton} canvasSingleton
+   */
+  renderFrame(frameState, canvasSingleton) {
+    if (this.layer.opacity === 0) return null
 
     const { declutterTree } = frameState
     const { projection, viewPortSize, sizeInPixels, visibleExtent, transform } =
@@ -96,10 +99,7 @@ export class TextLayerRenderer {
       const icon = featureStyle?.text?.icon
 
       if (callout || icon) {
-        canvasCtx ??= this.getOrCreateContainer(
-          targetElement,
-          sizeInPixels,
-        ).firstElementChild.getContext("2d")
+        canvasCtx ??= canvasSingleton.getContext2d()
       }
 
       if (callout) {
@@ -329,52 +329,6 @@ export class TextLayerRenderer {
     style.border = "1px solid red"
 
     return element
-  }
-
-  // NOTE: these are just copied over from VectorLayerRenderer - is there a nicer way of doing this?
-  getOrCreateContainer(targetElement, sizeInPixels) {
-    let container = null
-    let containerReused = false
-    let canvas = targetElement && targetElement.firstElementChild
-    if (canvas instanceof HTMLCanvasElement) {
-      // use container from previously rendered layer
-      container = targetElement
-      containerReused = true
-    } else if (this._container) {
-      // reuse existing container for this layer
-      container = this._container
-    } else {
-      // Create new container
-      container = this.createContainer()
-    }
-
-    if (!containerReused) {
-      // setting the size of the canvas also clears it
-      const canvas = container.firstElementChild
-      canvas.width = sizeInPixels[0]
-      canvas.height = sizeInPixels[1]
-    }
-
-    this._container = container
-    return container
-  }
-  createContainer() {
-    const container = document.createElement("div")
-    container.className = "gv-map-layer"
-
-    let style = container.style
-    style.position = "absolute"
-    style.width = "100%"
-    style.height = "100%"
-
-    const canvas = document.createElement("canvas")
-    style = canvas.style
-    style.position = "absolute"
-    style.width = "100%"
-    style.height = "100%"
-    container.appendChild(canvas)
-
-    return container
   }
 
   /**

--- a/src/lib/components/molecules/canvas-map/lib/renderers/TextLayerRenderer.js
+++ b/src/lib/components/molecules/canvas-map/lib/renderers/TextLayerRenderer.js
@@ -2,7 +2,13 @@ import { FeatureRenderer } from "./FeatureRenderer"
 import { replaceChildren } from "../util/dom"
 
 export class TextLayerRenderer {
+  /**
+   * @param {import("../layers/TextLayer").TextLayer} layer
+   */
   constructor(layer) {
+    /**
+     * @type {import("../layers/TextLayer").TextLayer}
+     */
     this.layer = layer
     this.featureRenderer = new FeatureRenderer()
 
@@ -24,12 +30,16 @@ export class TextLayerRenderer {
       frameState.viewState
 
     // set opacity
-    this._element.style.opacity = this.layer.opacity
+    this._element.style.opacity = `${this.layer.opacity}`
 
     const source = this.layer.source
     const features = source.getFeaturesInExtent(visibleExtent)
 
+    /** @type {CanvasRenderingContext2D} */
+    let canvasCtx
+
     const textElements = []
+
     for (const feature of features) {
       // get point geometry
       const geometries = feature.getProjectedGeometries(projection)
@@ -40,33 +50,39 @@ export class TextLayerRenderer {
         )
       }
 
-      // get style
       const styleFunction =
         feature.getStyleFunction() || this.layer.getStyleFunction()
-      const featureStyle = styleFunction(feature)
+
+      const featureStyle = styleFunction(feature, transform.k)
 
       // get text element
       const textElement = this.getTextElementWithID(feature.uid)
       textElement.innerText = featureStyle.text.content
 
-      // calculate relative position
-      const [relativeX, relativeY] = transform
-        .apply(point.coordinates)
-        .map((d, i) => d / sizeInPixels[i])
-      const position = {
-        left: `${relativeX * 100}%`,
-        top: `${relativeY * 100}%`,
-      }
+      const [canvasX, canvasY] = transform.apply(point.coordinates)
+      const [relativeX, relativeY] = [
+        canvasX / sizeInPixels[0],
+        canvasY / sizeInPixels[1],
+      ]
 
-      // apply style to text element
-      this.styleTextElement(textElement, featureStyle.text, position)
+      const position = this.getElementPosition(featureStyle.text, {
+        x: relativeX,
+        y: relativeY,
+      })
 
-      // skip item if it collides with existing elements
-      const bbox = this.getElementBBox(textElement, featureStyle.text, {
+      // Apply style to text element, and receive measured size from DOM
+      const elementDimens = this.styleTextElement(
+        textElement,
+        featureStyle.text,
+        position,
+      )
+
+      const bbox = this.getElementBBox(elementDimens, featureStyle.text, {
         x: relativeX * viewPortSize[0],
         y: relativeY * viewPortSize[1],
       })
 
+      // skip item if it collides with existing elements
       if (declutterTree) {
         if (declutterTree.collides(bbox)) {
           continue
@@ -74,6 +90,66 @@ export class TextLayerRenderer {
 
         // add element to declutter tree to prevent collisions
         declutterTree.insert(bbox)
+      }
+
+      const callout = featureStyle?.text?.callout
+      const icon = featureStyle?.text?.icon
+
+      if (callout || icon) {
+        canvasCtx ??= this.getOrCreateContainer(
+          targetElement,
+          sizeInPixels,
+        ).firstElementChild.getContext("2d")
+      }
+
+      if (callout) {
+        // Offsets are given in pixels, which we must scale to match canvas resolution
+        const canvasOffsetX =
+          (callout.offsetBy.x - callout.leaderGap) * window.devicePixelRatio
+
+        const canvasOffsetY = callout.offsetBy.y * window.devicePixelRatio
+
+        canvasCtx.beginPath()
+
+        canvasCtx.moveTo(canvasX, canvasY)
+        canvasCtx.lineTo(canvasX + canvasOffsetX / 2, canvasY + canvasOffsetY)
+        canvasCtx.moveTo(canvasX + canvasOffsetX / 2, canvasY + canvasOffsetY)
+        canvasCtx.lineTo(canvasX + canvasOffsetX, canvasY + canvasOffsetY)
+
+        canvasCtx.strokeStyle = callout.leaderColor
+        canvasCtx.lineWidth = callout.leaderWidth
+        canvasCtx.stroke()
+
+        canvasCtx.closePath()
+      }
+
+      if (icon) {
+        canvasCtx.beginPath()
+        canvasCtx.save()
+
+        let iconPosX = relativeX * viewPortSize[0]
+        let iconPosY = relativeY * viewPortSize[1]
+
+        if (callout) {
+          iconPosX += callout.offsetBy.x
+          iconPosY += callout.offsetBy.y
+        }
+
+        if (icon.position === "right") {
+          iconPosX += elementDimens.width
+        } else if (icon.position === "left") {
+          iconPosX += icon.padding + icon.size / 2
+        }
+
+        canvasCtx.translate(
+          iconPosX * window.devicePixelRatio,
+          iconPosY * window.devicePixelRatio,
+        )
+
+        this.drawTextIcon(canvasCtx, icon)
+
+        canvasCtx.restore()
+        canvasCtx.closePath()
       }
 
       if (this.layer.drawCollisionBoxes) {
@@ -101,6 +177,7 @@ export class TextLayerRenderer {
 
   styleTextElement(element, textStyle, position) {
     const style = element.style
+
     style.position = "absolute"
     style.left = position.left
     style.top = position.top
@@ -115,7 +192,10 @@ export class TextLayerRenderer {
     style.textShadow = textStyle.textShadow
 
     const { width, height } = this.getElementSize(element)
+
     style.transform = textStyle.getTransform(width, height)
+
+    return { width, height }
   }
 
   getElementSize(element) {
@@ -132,32 +212,108 @@ export class TextLayerRenderer {
     return { width, height }
   }
 
-  getElementBBox(element, textStyle, position) {
-    const collissionPadding = {
+  /**
+   * @param {{ height: number, width: number }} dimens
+   * @param {import("../styles/Text").Text} textStyle
+   * @param {{x: number, y: number}} position
+   */
+  getElementBBox(dimens, textStyle, position) {
+    const collisionPadding = {
       top: 2,
       right: 2,
       bottom: 2,
       left: 2,
     }
 
-    const { width, height } = this.getElementSize(element)
     const { x: translateX, y: translateY } = textStyle.getTranslation(
-      width,
-      height,
+      dimens.width,
+      dimens.height,
     )
 
-    const minX = Math.floor(position.x + translateX - collissionPadding.left)
-    const minY = Math.floor(position.y + translateY - collissionPadding.top)
+    let minX = position.x + translateX - collisionPadding.left
+    let minY = position.y + translateY - collisionPadding.top
+
+    let maxX =
+      minX + dimens.width + collisionPadding.left + collisionPadding.right
+    let maxY =
+      minY + dimens.height + collisionPadding.top + collisionPadding.bottom
+
+    if (textStyle.callout) {
+      minX += textStyle.callout.offsetBy.x
+      minY += textStyle.callout.offsetBy.y
+      maxX += textStyle.callout.offsetBy.x
+      maxY += textStyle.callout.offsetBy.y
+    }
+
+    if (textStyle.icon) {
+      if (
+        textStyle.icon.position === "left" ||
+        textStyle.icon.position === "right"
+      ) {
+        maxX += textStyle.icon.size + textStyle.icon.padding
+      }
+
+      const iconSizeHeightDiff = textStyle.icon.size - dimens.height
+
+      if (iconSizeHeightDiff > 0) {
+        minY -= iconSizeHeightDiff / 2
+        maxY += iconSizeHeightDiff / 2
+      }
+    }
+
+    minX = Math.floor(minX)
+    minY = Math.floor(minY)
+    maxX = Math.ceil(maxX)
+    maxY = Math.ceil(maxY)
 
     return {
       minX,
       minY,
-      maxX: Math.ceil(
-        minX + width + collissionPadding.left + collissionPadding.right,
-      ),
-      maxY: Math.ceil(
-        minY + height + collissionPadding.top + collissionPadding.bottom,
-      ),
+      maxX,
+      maxY,
+    }
+  }
+
+  /**
+   * @param {import("../styles/Text").Text} textStyle
+   * @param {{x: number, y: number}} position
+   */
+  getElementPosition(textStyle, position) {
+    if (textStyle.callout) {
+      if (textStyle.icon.position === "left") {
+        return {
+          left: `calc(${position.x * 100}% + ${textStyle.callout.offsetBy.x + (textStyle.icon.size + textStyle.icon.padding * 2)}px)`,
+          top: `calc(${position.y * 100}% + ${textStyle.callout.offsetBy.y}px)`,
+        }
+      }
+
+      if (textStyle.icon.position === "right") {
+        return {
+          left: `calc(${position.x * 100}% + ${textStyle.callout.offsetBy.x}px)`,
+          top: `calc(${position.y * 100}% + ${textStyle.callout.offsetBy.y}px)`,
+        }
+      }
+
+      return {
+        left: `calc(${position.x * 100}% + ${textStyle.callout.offsetBy.x}px)`,
+        top: `calc(${position.y * 100}% + ${textStyle.callout.offsetBy.y}px)`,
+      }
+    }
+
+    if (
+      textStyle.icon &&
+      (textStyle.icon.position === "left" ||
+        textStyle.icon.position === "right")
+    ) {
+      return {
+        left: `calc(${position.x * 100}% + ${textStyle.icon.size + textStyle.icon.padding * 2}px)`,
+        top: `${position.y * 100}%`,
+      }
+    }
+
+    return {
+      left: `${position.x * 100}%`,
+      top: `${position.y * 100}%`,
     }
   }
 
@@ -173,5 +329,87 @@ export class TextLayerRenderer {
     style.border = "1px solid red"
 
     return element
+  }
+
+  // NOTE: these are just copied over from VectorLayerRenderer - is there a nicer way of doing this?
+  getOrCreateContainer(targetElement, sizeInPixels) {
+    let container = null
+    let containerReused = false
+    let canvas = targetElement && targetElement.firstElementChild
+    if (canvas instanceof HTMLCanvasElement) {
+      // use container from previously rendered layer
+      container = targetElement
+      containerReused = true
+    } else if (this._container) {
+      // reuse existing container for this layer
+      container = this._container
+    } else {
+      // Create new container
+      container = this.createContainer()
+    }
+
+    if (!containerReused) {
+      // setting the size of the canvas also clears it
+      const canvas = container.firstElementChild
+      canvas.width = sizeInPixels[0]
+      canvas.height = sizeInPixels[1]
+    }
+
+    this._container = container
+    return container
+  }
+  createContainer() {
+    const container = document.createElement("div")
+    container.className = "gv-map-layer"
+
+    let style = container.style
+    style.position = "absolute"
+    style.width = "100%"
+    style.height = "100%"
+
+    const canvas = document.createElement("canvas")
+    style = canvas.style
+    style.position = "absolute"
+    style.width = "100%"
+    style.height = "100%"
+    container.appendChild(canvas)
+
+    return container
+  }
+
+  /**
+   * Draws a `Text` element's icon on the canvas.
+   *
+   * Expects the canvas context to be translated to the text element's position.
+   *
+   * TODO: support more shapes?
+   *
+   * @param {CanvasRenderingContext2D} context
+   * @param {import("../styles/Text").IconOptions} icon
+   */
+  drawTextIcon(context, icon) {
+    if (icon.shape === "circle") {
+      context.arc(
+        0,
+        0,
+        (icon.size * devicePixelRatio) / 2,
+        0,
+        2 * Math.PI,
+        false,
+      )
+
+      if (icon.style) {
+        icon.style.fill?.drawInContext(context)
+
+        if (icon.style.stroke) {
+          context.lineWidth = icon.style.stroke.width
+          context.strokeStyle = icon.style.stroke.getRgba()
+          context.stroke()
+        }
+      } else if (icon.color) {
+        context.fillStyle = icon.color
+        context.fill()
+      }
+    }
   }
 }

--- a/src/lib/components/molecules/canvas-map/lib/renderers/VectorLayerRenderer.js
+++ b/src/lib/components/molecules/canvas-map/lib/renderers/VectorLayerRenderer.js
@@ -13,14 +13,15 @@ export class VectorLayerRenderer {
     this.featureRenderer = new FeatureRenderer()
   }
 
-  renderFrame(frameState, targetElement) {
-    if (this.layer.opacity === 0) return targetElement
+  /**
+   * @param {import("./MapRenderer").CanvasSingleton} canvasSingleton
+   */
+  renderFrame(frameState, canvasSingleton) {
+    if (this.layer.opacity === 0) return null
 
-    const { projection, sizeInPixels, visibleExtent, transform } =
-      frameState.viewState
+    const { projection, visibleExtent, transform } = frameState.viewState
 
-    const container = this.getOrCreateContainer(targetElement, sizeInPixels)
-    const context = container.firstElementChild.getContext("2d")
+    const context = canvasSingleton.getContext2d()
 
     context.save()
 
@@ -65,53 +66,5 @@ export class VectorLayerRenderer {
     }
 
     context.restore()
-
-    return container
-  }
-
-  getOrCreateContainer(targetElement, sizeInPixels) {
-    let container = null
-    let containerReused = false
-    let canvas = targetElement && targetElement.firstElementChild
-    if (canvas instanceof HTMLCanvasElement) {
-      // use container from previously rendered layer
-      container = targetElement
-      containerReused = true
-    } else if (this._container) {
-      // reuse existing container for this layer
-      container = this._container
-    } else {
-      // Create new container
-      container = this.createContainer()
-    }
-
-    if (!containerReused) {
-      // setting the size of the canvas also clears it
-      const canvas = container.firstElementChild
-      canvas.width = sizeInPixels[0]
-      canvas.height = sizeInPixels[1]
-    }
-
-    this._container = container
-    return container
-  }
-
-  createContainer() {
-    const container = document.createElement("div")
-    container.className = "gv-map-layer"
-
-    let style = container.style
-    style.position = "absolute"
-    style.width = "100%"
-    style.height = "100%"
-
-    const canvas = document.createElement("canvas")
-    style = canvas.style
-    style.position = "absolute"
-    style.width = "100%"
-    style.height = "100%"
-    container.appendChild(canvas)
-
-    return container
   }
 }

--- a/src/lib/components/molecules/canvas-map/lib/renderers/VectorLayerRenderer.js
+++ b/src/lib/components/molecules/canvas-map/lib/renderers/VectorLayerRenderer.js
@@ -1,7 +1,14 @@
 import { FeatureRenderer } from "./FeatureRenderer"
 
 export class VectorLayerRenderer {
+  /**
+   * @constructor
+   * @param {import('../layers').VectorLayer} layer
+   */
   constructor(layer) {
+    /**
+     * @type {import('../layers').VectorLayer}
+     */
     this.layer = layer
     this.featureRenderer = new FeatureRenderer()
   }
@@ -27,13 +34,17 @@ export class VectorLayerRenderer {
     // set opacity
     context.globalAlpha = this.layer.opacity
 
+    // TODO: why isn't this typed?
     const source = this.layer.source
     const features = source.getFeaturesInExtent(visibleExtent)
 
     for (const feature of features) {
+      /** @type {import("../styles").StyleFunction} */
       const styleFunction =
         feature.getStyleFunction() || this.layer.getStyleFunction()
-      const featureStyle = styleFunction(feature)
+
+      const featureStyle = styleFunction(feature, transform.k)
+
       if (featureStyle?.stroke || featureStyle?.fill) {
         context.save()
         this.featureRenderer.setStyle(featureStyle)

--- a/src/lib/components/molecules/canvas-map/lib/sources/VectorSource.js
+++ b/src/lib/components/molecules/canvas-map/lib/sources/VectorSource.js
@@ -3,10 +3,12 @@ import knn from "rbush-knn"
 import { Dispatcher, MapEvent } from "../events"
 
 export class VectorSource {
+  /**
+   * @param {Object} props
+   * @param {import("../Feature").Feature[]} props.features
+   */
   constructor({ features }) {
     this.dispatcher = new Dispatcher(this)
-
-    // create spatial index
     this._featuresRtree = new RBush()
     this.setFeatures(features)
   }
@@ -15,10 +17,17 @@ export class VectorSource {
     this.dispatcher = null
   }
 
+  /**
+   * @returns {import("../Feature").Feature[]}
+   */
   getFeatures() {
     return this._features
   }
 
+  /**
+   * @param {[number, number]} coordinate
+   * @returns {import("../Feature").Feature[]}
+   */
   getFeaturesAtCoordinate(coordinate) {
     const [x, y] = coordinate
     const items = knn(this._featuresRtree, x, y, 10, (d) => {
@@ -34,6 +43,10 @@ export class VectorSource {
     return items.map((d) => d.feature)
   }
 
+  /**
+   * @param {[number, number, number, number]} extent TODO: should this be an `Extent`?
+   * @returns {import("../Feature").Feature[]}
+   */
   getFeaturesInExtent(extent) {
     const [minX, minY, maxX, maxY] = extent
 
@@ -44,6 +57,9 @@ export class VectorSource {
     return features
   }
 
+  /**
+   * @param {import("../Feature").Feature[]} features
+   */
   setFeatures(features) {
     this._featuresRtree.clear()
 

--- a/src/lib/components/molecules/canvas-map/lib/styles/Style.js
+++ b/src/lib/components/molecules/canvas-map/lib/styles/Style.js
@@ -1,7 +1,12 @@
 /**
- * A function that takes a {@link import("../Feature").Feature} and returns a {@link Style}
+ * @import { Text } from "./Text";
+ * @import { Stroke } from "./Stroke"
+ * @import { Fill } from "./Fill"
  *
- * @typedef {function(import("../Feature").Feature):(Style)} StyleFunction
+ * @callback StyleFunction
+ * @param {import("../Feature").Feature} feature The feature to style.
+ * @param {number} zoom The current map zoom level
+ * @returns {Style}
  */
 
 /**
@@ -14,9 +19,28 @@
  * @property {number} properties.pointRadius - Radius of drawn "Point"-type geometries, if present
  */
 export class Style {
+  /**
+   * @param {Object} [properties]
+   * @param {Stroke} [properties.stroke]
+   * @param {Fill} [properties.fill]
+   * @param {Text} [properties.text]
+   * @param {number} [properties.pointRadius]
+   */
   constructor(properties) {
+    /**
+     * @type {Stroke}
+     * @public
+     */
     this.stroke = properties?.stroke
+    /**
+     * @type {Fill}
+     * @public
+     */
     this.fill = properties?.fill
+    /**
+     * @type {Text}
+     * @public
+     */
     this.text = properties?.text
     this.pointRadius = properties?.pointRadius
   }

--- a/src/lib/components/molecules/canvas-map/lib/styles/Text.js
+++ b/src/lib/components/molecules/canvas-map/lib/styles/Text.js
@@ -28,6 +28,45 @@ const TextAnchor = {
 }
 
 /**
+ * TODO: add leader 'style' option, e.g. kink, direct, manhattan, etc.
+ *
+ * @typedef CalloutOptions
+ * @property {{ x: number, y: number }} offsetBy { x, y } offset in pixels, relative to the text position.
+ *
+ * E.g. { x: 10, y: 20 } will move the callout 10 pixels to the right and 20 pixels down.
+ * @property {number} [leaderGap=5] Distance in pixels between the leader line and the text
+ * @property {string} [leaderColor="#121212"] Hex colour of the leader line
+ * @property {number} [leaderWidth=1] Stroke width of the leader line
+ */
+
+/**
+ * @typedef IconOptions
+ *
+ * @property {"circle"} [shape="circle"]
+ * Shape of the icon.
+ *
+ * TODO: add more shapes?
+ * @property {"left" | "right" | "center" } [position="left"] Position of the icon relative to the text.
+ *
+ * If "center", the icon is placed exactly on the text's coordinates. Use the `anchor` and
+ * `radialOffset` properties of `Text` to place the text relative to the icon.
+ * place the text relative to the icon.
+ * Position of the icon relative to the text
+ * @property {number} [size=10]
+ * Size of the icon in pixels
+ * @property {number} [padding]
+ * Distance in pixels between the icon and the text
+ * @property {string} [color]
+ * Hex colour of the icon, e.g. "#ff0000"
+ *
+ * For more advanced styling, use the `style` property.
+ * @property {import('../styles/Style').Style} [style]
+ * Style of the icon.
+ *
+ * Note that `stroke.position: "inside"` is not currently supported.
+ */
+
+/**
  * @typedef TextStyle
  * @property {string} content - The text to render
  * @property {string} [id] - The id of the text element
@@ -39,18 +78,24 @@ const TextAnchor = {
  * @property {string} [fontSize="17px"] - The font size of the text
  * @property {string} [fontWeight="400"] - The font weight of the text
  * @property {number} [radialOffset=0] - The radial offset of the text in ems
+ * @property {CalloutOptions} [callout] Options for offsetting the text and drawing a leader line.
+ *
+ * If not provided, no leader line is drawn.
+ * @property {IconOptions} [icon] Options for a simple icon displayed next to the text.
+ *
+ * If not provided, no icon is drawn.
  */
 
 /**
  * Class that represents a text style
- * @type Text
+ * @class
  * @implements {TextStyle}
  */
 export class Text {
   /**
    * Create a text element style
    * @constructor
-   * @param {TextStyle} [options] - Style options
+   * @param {TextStyle} [options] Style options
    */
   constructor(options) {
     this.content = options?.content
@@ -61,9 +106,26 @@ export class Text {
     this.lineHeight = options?.lineHeight || 1.3
     this.color = options?.color || "#121212"
     this.textShadow =
-      options?.textShadow ||
+      options?.textShadow ??
       "1px 1px 0px #f6f6f6, -1px -1px 0px #f6f6f6, -1px 1px 0px #f6f6f6, 1px -1px #f6f6f6"
     this.radialOffset = options?.radialOffset || 0
+
+    // TODO: offer simple "length" + "angle" instead?
+    if (options.callout) {
+      this.callout = options.callout
+      this.callout.offsetBy ??= { x: 0, y: 0 }
+      this.callout.leaderGap ??= 5
+      this.callout.leaderColor ??= "#121212"
+      this.callout.leaderWidth ??= 1
+    }
+
+    if (options.icon) {
+      this.icon = options.icon
+      this.icon.shape ??= "circle"
+      this.icon.position ??= "left"
+      this.icon.size ??= 10
+      this.icon.padding ??= 5
+    }
   }
 
   /**
@@ -108,7 +170,7 @@ export class Text {
     let y = (translate.y / 100) * elementHeight
 
     const radialOffsetInPixels =
-      this.radialOffset * this.fontSize.replace("px", "")
+      this.radialOffset * parseInt(this.fontSize.replace("px", ""))
 
     switch (this.anchor) {
       case TextAnchor.TOP:

--- a/src/lib/components/molecules/canvas-map/map.stories.jsx
+++ b/src/lib/components/molecules/canvas-map/map.stories.jsx
@@ -619,14 +619,35 @@ export const UKMap = {
     const constituenciesFeatures = new GeoJSON().readFeaturesFromObject(
       constituencies,
     )
+
     const citiesFeatures = new GeoJSON().readFeaturesFromObject(ukCitiesGeo)
 
     const fillStyle = new Style({
       fill: new Fill({ color: "#f1f1f1" }),
     })
+
     const strokeStyle = new Style({
       stroke: new Stroke({ color: "#999", width: 1 }),
     })
+
+    const dundeeStyle = (currentZoom) =>
+      new Style({
+        text: new Text({
+          content: "Dundee",
+          anchor: "left",
+          callout: currentZoom < 4 && {
+            offsetBy: { x: 70, y: 20 },
+            leaderGap: 2,
+          },
+          icon: {
+            size: 10,
+            padding: 2,
+            style: new Style({
+              fill: new Fill({ color: "#FF22E0" }),
+            }),
+          },
+        }),
+      })
 
     return (
       <Map.Component {...args}>
@@ -641,11 +662,19 @@ export const UKMap = {
         />
         <TextLayer.Component
           features={citiesFeatures}
-          style={(feature) =>
-            new Style({
-              text: new Text({ content: feature.properties.name }),
-            })
-          }
+          style={(feature, currentZoom) => {
+            if (feature.properties.name === "Dundee") {
+              return dundeeStyle(currentZoom)
+            } else {
+              return new Style({
+                text: new Text({
+                  content: feature.properties.name,
+                  radialOffset: 0,
+                  anchor: "left",
+                }),
+              })
+            }
+          }}
         />
       </Map.Component>
     )


### PR DESCRIPTION
This PR adds new _callout_ and _icon_ features to the `TextLayer` component, which lets us draw map labels that look like this.

<img width="500" src="https://github.com/user-attachments/assets/5d1d4b22-f7f5-4eeb-9481-b31edf3a8e7b">

## Using the new features

Both of these features are made available through the `Text` class, provided to `Style`.

`callout`'s main property is `offsetBy`, which lets you declare how far away you'd like the label to be placed. There are other properties that allow you to customise padding, leader line width and colour.

`icon` provides a bunch of properties to customise a canvas-drawn circle (other shapes will need to be implemented). Crucially, its `style` property accepts a `Style` instance, meaning you can re-use existing logic for styling map features.

```jsx
return new Style({
  stroke: null,
  text: new Text({
    anchor: "left",
    content: feature.properties.text,
    callout: {
      offsetBy: { x: 50, y: 20 },
    },
    icon: {
      size: 14,
      padding: 4,
      style: getStatePresidentialResultStyle(feature.properties.results),
    },
  }),
})
```

## Limitations and continuing work

These changes are far from perfect, work here will be continued. The main points of improvement are:

* support other shapes, currently only circle icons can be drawn)
* add callout "groups" so callouts can be easily lined up
* fix text anchor behaviour, the leader line and icon don't play very well with anchors other than "left"
* tidy up code changes in `TextLayerRenderer` (the code there is still pretty WIP, so didn't want to clean it up too mcuh only to unpack it for further changes)
* draw icons as SVGs vs in canvas? this would make some of the geometry easier

## Notable changes

### `zoom` parameter in style functions

We often want to apply different styles depending on zoom level, especially in situations like this, where we may want to only make a label a "callout" with a leader line if the map is zoomed out enough.

To make it easier to say "display label as a callout when zoom > 4, otherwise show label at point", the callback that we pass to `TextLayer` and `VectorLayer`'s `style` prop will now be given the current map zoom level.

This lets us write code that looks like this. Notice the `callout: currentZoom < 4 &&` snippet...

```jsx
const style = (feature, currentZoom) =>
  new Style({
    text: new Text({
      content: feature.properties.text
      anchor: "left",
      callout: currentZoom < 4 && {
        offsetBy: { x: 70, y: 20 },
        leaderGap: 2,
      },
      icon: {
        size: 10,
        padding: 2,
        style: new Style({
          fill: new Fill({ color: "#FF22E0" }),
        }),
      },
    }),
  })
```

### Fix re: sharing the canvas between layers

Between all of the `TextLayer`s and `VectorLayer`s that we render, we try to keep a single canvas instance that's drawn to by all of them.

Currently, we do this by having the `VectorLayer` create a canvas if one doesn't already exist, then return it so it can be shared with other layers.

https://github.com/guardian/interactive-component-library/blob/a4966e37781338aa5c061811a14cb90613ec38ce/src/lib/components/molecules/canvas-map/lib/renderers/MapRenderer.js#L39-L46

See how we're doing `previousElement = element`, then passing `previousElement` to the next `layer.renderFrame` call? That's basically how we share the canvas between layers, but this logic breaks when we have `TextLayer`s mixed in with `VectorLayer`s, which do not return a canvas.

This PR includes a fix that adds a "canvas singleton", managed by the `MapRenderer`, and handed down to the layers. 

### More types in `TextLayer`, `VectorLayer`, and neighbouring components

I've added more JSDoc types to these components so type checking is more active when using them.

