### PR TITLE
Results card: create slim version

### DIFF
--- a/src/lib/components/molecules/result-summary/index.jsx
+++ b/src/lib/components/molecules/result-summary/index.jsx
@@ -1,5 +1,5 @@
 import { ControlChange } from "$molecules"
-import { RelativeTimeSentence } from "$particles"
+import { RelativeTimeSentence, GradientIcon, CircleIcon } from "$particles"
 import { mergeStyles } from "$styles/helpers/mergeStyles"
 import defaultStyles from "./style.module.css"
 
@@ -9,15 +9,39 @@ export function ResultSummary({
   title,
   text,
   timestamp,
+  isSlim = false,
   styles,
 }) {
   styles = mergeStyles({ ...defaultStyles }, styles)
 
-  return (
-    <div className={styles.container}>
-      <ControlChange previous={previous} next={next} text={title} />
-      <p className={styles.paragraph}>{text}</p>
-      <RelativeTimeSentence timeStamp={timestamp} />
-    </div>
-  )
+  if (isSlim) {
+    let hasChanged = next !== previous
+
+    return (
+      <div className={`${styles.container} ${styles.containerSlim}`}>
+        {hasChanged ? (
+          <GradientIcon
+            previous={previous}
+            next={next}
+            styles={{
+              previous: styles.previous,
+              next: styles.next,
+            }}
+          />
+        ) : (
+          <CircleIcon styles={{ circle: `fill-color--${next}` }} />
+        )}
+        <p className={styles.titleSlim}>{title} </p>
+        <RelativeTimeSentence timeStamp={timestamp} />
+      </div>
+    )
+  } else {
+    return (
+      <div className={styles.container}>
+        <ControlChange previous={previous} next={next} text={title} />
+        <p className={styles.paragraph}>{text}</p>
+        <RelativeTimeSentence timeStamp={timestamp} />
+      </div>
+    )
+  }
 }

--- a/src/lib/components/molecules/result-summary/result-summary.stories.jsx
+++ b/src/lib/components/molecules/result-summary/result-summary.stories.jsx
@@ -29,3 +29,13 @@ export const Default = {
     timestamp,
   },
 }
+
+export const Slim = {
+  args: {
+    previous: "gop",
+    next: "dem",
+    title: "Harris flips Arizona, a key swing state",
+    timestamp,
+    isSlim: true,
+  },
+}

--- a/src/lib/components/molecules/result-summary/style.module.css
+++ b/src/lib/components/molecules/result-summary/style.module.css
@@ -9,6 +9,25 @@
   height: 100%;
 }
 
+.containerSlim {
+  min-width: 260px;
+  display: inline-block;
+}
+
+.titleSlim {
+  display: inline;
+  color: var(--primary-text-color) !important;
+  font-family: var(--text-sans) !important;
+  font-size: var(--sans-small) !important;
+  line-height: var(--sans-line-height) !important;
+  font-weight: 700 !important;
+  margin-left: var(--space-1) !important;
+}
+
+.dateStampLinePosition {
+  display: block;
+}
+
 .paragraph {
   font-family: var(--text-sans);
   font-size: var(--sans-xsmall);


### PR DESCRIPTION
Pushing the datestamp onto the same line as the title of the card required much more rebuilding than I would like but 🤷‍♀️ 

I could no longer use the <ControlChange> component because its structure didn't give enough styling flexibility so have pasted it with a few adjustments in the <ResultsSummary>

New property `isSlim` controls if you see this or the default 

Datestamp span can be optionally bumped onto the next line with CSS injected from the client 

![Screenshot 2024-10-04 at 17 01 31](https://github.com/user-attachments/assets/79773be3-d300-49fd-9081-52d810594f33)
