### PR TITLE
Ticker: remove default width, allow children to set their own

### DIFF
--- a/src/lib/components/molecules/result-summary/style.module.css
+++ b/src/lib/components/molecules/result-summary/style.module.css
@@ -7,6 +7,7 @@
   flex-direction: column;
   row-gap: var(--space-0);
   height: 100%;
+  width: 100%;
 }
 
 .paragraph {

--- a/src/lib/components/organisms/ticker/style.module.scss
+++ b/src/lib/components/organisms/ticker/style.module.scss
@@ -2,17 +2,17 @@
   position: relative;
   padding-bottom: 44px;
 
-  --ticker-item-width: 100%;
+  // --ticker-item-width: 100%;
 
   @include mq($from: mobileLandscape) {
-    --ticker-item-width: auto;
+    // --ticker-item-width: auto;
     padding: 0;
   }
 }
 
 .ticker {
   position: relative;
-  --ticker-item-width: 200px;
+  // --ticker-item-width: 200px;
   padding: 0;
   cursor: default;
 }
@@ -61,8 +61,9 @@
 }
 
 .tickerItem {
-  width: var(--ticker-item-width);
-  flex-shrink: 0;
+  // width: var(--ticker-item-width);
+  flex: 1 0 auto;
+  // flex-shrink: 0;
 }
 
 .controls {

--- a/src/lib/components/organisms/ticker/ticker.stories.jsx
+++ b/src/lib/components/organisms/ticker/ticker.stories.jsx
@@ -117,11 +117,34 @@ export const LongTitleAndText = {
   },
 }
 
+const itemsSlim = [
+  {
+    previous: "dem",
+    next: "gop",
+    title: "Trump flips Arizona, a key swing state",
+    text: "",
+    isSlim: true,
+  },
+  {
+    previous: "gop",
+    next: "gop",
+    title: "Trump holds Florida",
+    isSlim: true,
+  },
+  {
+    previous: "dem",
+    next: "dem",
+    title: "Harris holds California",
+    isSlim: true,
+  },
+]
+
 export const VerticalAtMobile = {
   args: {
     verticalAtMobile: true,
     maxItems: 12,
-    items: [...items, ...items, ...items, ...items],
+    itemWidth: "100%",
+    items: [...itemsSlim, ...itemsSlim, ...itemsSlim, ...itemsSlim],
   },
 }
 
@@ -129,7 +152,8 @@ export const HorizontalAtMobile = {
   args: {
     verticalAtMobile: false,
     maxItems: 12,
-    items: [...items, ...items, ...items, ...items],
+    itemWidth: "260px",
+    items: [...itemsSlim, ...itemsSlim, ...itemsSlim, ...itemsSlim],
   },
 }
 


### PR DESCRIPTION
Following requests to have more flexible sizes for Results Cards commonly used in the Ticker, and changes to the Results Cards: https://github.com/guardian/interactive-component-library/pull/290

This PR makes the above changes play better with the Ticker, adding some stories for the new slimline Results cards and removing the Ticker's default item width. This should now be set by the children and respected by the Ticker. 

A CSS override re-adding the functionality can be added back  if people want it 

Examples: 

Vertical mobile ticker - width defaults to 100% 
![Screenshot 2024-10-07 at 14 54 22](https://github.com/user-attachments/assets/302fe6f8-b2f4-40de-bd08-247ecd91c640)

Horizontal mobile ticker - width depends on width set by child
![Screenshot 2024-10-07 at 14 54 03](https://github.com/user-attachments/assets/5ec11798-eb85-4424-bbdf-9df65453b9cc)

