### PR TITLE
Results Summary: add onClick event

### DIFF
--- a/src/lib/components/molecules/result-summary/index.jsx
+++ b/src/lib/components/molecules/result-summary/index.jsx
@@ -9,6 +9,7 @@ export function ResultSummary({
   title,
   text,
   timestamp,
+  onClick,
   isSlim = false,
   styles,
 }) {
@@ -18,7 +19,10 @@ export function ResultSummary({
     let hasChanged = next !== previous
 
     return (
-      <div className={`${styles.container} ${styles.containerSlim}`}>
+      <div
+        className={`${styles.container} ${styles.containerSlim}`}
+        onClick={onClick}
+      >
         {hasChanged ? (
           <GradientIcon
             previous={previous}


### PR DESCRIPTION
So that ticker cards can be clicked on to select a new result, this ResultsSummary component needs an onClick event to be passed thru 

