### PR TITLE
Fix LineString rendering bug

### DIFF
--- a/src/lib/components/molecules/canvas-map/lib/renderers/FeatureRenderer.js
+++ b/src/lib/components/molecules/canvas-map/lib/renderers/FeatureRenderer.js
@@ -76,8 +76,6 @@ export class FeatureRenderer {
 
     if (clipPath) {
       context.clip()
-    } else {
-      context.closePath()
     }
   }
 


### PR DESCRIPTION
This fixes an issue where LineString features were not drawn correctly because `FeatureRenderer` would always close the path.