### PR TITLE
Ticker card animation: use preact-transitioning with csstransition + transitiongroup

### DIFF
--- a/src/lib/components/organisms/ticker/index.jsx
+++ b/src/lib/components/organisms/ticker/index.jsx
@@ -102,14 +102,6 @@ export function Ticker({
                 <CSSTransition
                   key={child?.props?.id ?? index}
                   duration={600}
-                  onEnter={(node) => {
-                    let width = node.getBoundingClientRect().width
-                    node.style = `transform: translateX(-${width}px);`
-                  }}
-                  onEntered={(node) => {
-                    node.style =
-                      "transform: translateX(0px); transition: transform 600ms ease-out;"
-                  }}
                   classNames={styles}
                 >
                   <div className={styles.tickerItem}>{child}</div>

--- a/src/lib/components/organisms/ticker/index.jsx
+++ b/src/lib/components/organisms/ticker/index.jsx
@@ -7,6 +7,7 @@ import {
   useEffect,
   useCallback,
 } from "preact/hooks"
+import { CSSTransition, TransitionGroup } from "preact-transitioning"
 import { useContainerSize } from "$shared/hooks/useContainerSize"
 import { TickerControlsDesktop } from "./lib/TickerControlsDesktop"
 import { TickerControlsMobileVertical } from "./lib/TickerControlsMobileVertical"
@@ -95,11 +96,27 @@ export function Ticker({
             verticalAtMobile ? styles.tickerScrollVertical : styles.tickerScroll
           }
         >
-          {childArray.map((child, index) => (
-            <div className={styles.tickerItem} key={child?.props?.id ?? index}>
-              {child}
-            </div>
-          ))}
+          {Array.isArray(childArray) && childArray.length > 0 && (
+            <TransitionGroup>
+              {childArray.map((child, index) => (
+                <CSSTransition
+                  key={child?.props?.id ?? index}
+                  duration={600}
+                  onEnter={(node) => {
+                    let width = node.getBoundingClientRect().width
+                    node.style = `transform: translateX(-${width}px);`
+                  }}
+                  onEntered={(node) => {
+                    node.style =
+                      "transform: translateX(0px); transition: transform 600ms ease-out;"
+                  }}
+                  classNames={styles}
+                >
+                  <div className={styles.tickerItem}>{child}</div>
+                </CSSTransition>
+              ))}
+            </TransitionGroup>
+          )}
         </div>
       </div>
 
@@ -123,6 +140,7 @@ export function Ticker({
           setPageIndex={setPageIndex}
           pageIndex={pageIndex}
           numberOfPages={numberOfPages}
+          tickerScrollRef={tickerScrollRef}
         />
       )}
     </div>

--- a/src/lib/components/organisms/ticker/style.module.scss
+++ b/src/lib/components/organisms/ticker/style.module.scss
@@ -52,7 +52,8 @@
   padding-right: 50px;
 
   &:-webkit-scrollbar {
-    display: none; /* for Chrome, Safari, and Opera */
+    display: none;
+    /* for Chrome, Safari, and Opera */
   }
 
   @include mq(mobileLandscape) {
@@ -63,30 +64,31 @@
 .tickerItem {
   width: var(--ticker-item-width);
   flex-shrink: 0;
-  // transform: translateX(0);
-  // transition: transform 900ms ease-out;
+  transition: transform 300ms ease-out;
 }
 
 // TRANSITION CLASSES FOR ANIMATING CARDS IN AND OUT
 // a translateX(-250px) position is instead set in onEnter property on CSSTransition
 
-// .appearActive {
-//   transform: translateX(-260px);
-//   transition: transform 900ms ease-out;
-// }
+.appear {
+  transform: translateX(-100%);
+}
 
-// .appearDone {
-//   transform: translateX(0);
-// }
+.appearActive {
+  transform: translateX(0);
+}
 
-/* TODO: this *should* work, but doesn't seem to :( */
-// .appear~.appearDone {
-// 	transform: translateX(-200px);
-// }
+.appear ~ .appearDone {
+  transform: translateX(-100%);
+  /* Disable transition so following items are immediately moved left, to be animated to the right
+    with the rule below */
+  transition: unset;
+}
 
-// .appear-active~.appearDone {
-// 	transform: translateX(0px);
-// }
+.appearActive ~ .appearDone {
+  transform: translateX(0);
+  transition: transform 300ms ease-out;
+}
 
 .controls {
   position: absolute;
@@ -113,6 +115,7 @@
     right: 0;
   }
 }
+
 .gradientHorizontal {
   pointer-events: none;
   width: 60px;
@@ -126,6 +129,7 @@
     var(--tertiary-bg-color) 80%,
     var(--tertiary-bg-color)
   );
+
   @include mq($from: mobileLandscape) {
     width: auto;
   }

--- a/src/lib/components/organisms/ticker/style.module.scss
+++ b/src/lib/components/organisms/ticker/style.module.scss
@@ -63,7 +63,30 @@
 .tickerItem {
   width: var(--ticker-item-width);
   flex-shrink: 0;
+  // transform: translateX(0);
+  // transition: transform 900ms ease-out;
 }
+
+// TRANSITION CLASSES FOR ANIMATING CARDS IN AND OUT
+// a translateX(-250px) position is instead set in onEnter property on CSSTransition
+
+// .appearActive {
+//   transform: translateX(-260px);
+//   transition: transform 900ms ease-out;
+// }
+
+// .appearDone {
+//   transform: translateX(0);
+// }
+
+/* TODO: this *should* work, but doesn't seem to :( */
+// .appear~.appearDone {
+// 	transform: translateX(-200px);
+// }
+
+// .appear-active~.appearDone {
+// 	transform: translateX(0px);
+// }
 
 .controls {
   position: absolute;


### PR DESCRIPTION
Using preact transitioning library to attempt a slide-in animation as new cards are added to the ticker 


https://github.com/user-attachments/assets/1fce2ae6-c5f3-41d5-a9e7-6e16a33ac751


Working: 
- a new element animates in, sliding in from the left 

Not working: 
- the other elements in the transition group do react to the new element (they move to the right) but this movement is not transitioned or animated. 

NB: more classically you would add classes to the element that should animate: `.appear` `.appearDone` etc. But these just didn't get applied quickly enough when I used them. So there was a jump before they got applied. So I switched to using CSSTransition properties `onEnter` and `onEntered` which do seem to kick in at the correct times. 


Setting the .tickerItem default CSS to `transform: translateX(-250px)` had problems as well, especially in the initial state. 