### PR TITLE
Offer `offsetTo` instead of `offsetBy` in `TextLayer`

### DIFF
--- a/src/lib/components/molecules/canvas-map/lib/styles/Text.js
+++ b/src/lib/components/molecules/canvas-map/lib/styles/Text.js
@@ -31,9 +31,9 @@ const TextAnchor = {
  * TODO: add leader 'style' option, e.g. kink, direct, manhattan, etc.
  *
  * @typedef CalloutOptions
- * @property {{ x: number, y: number }} offsetBy { x, y } offset in pixels, relative to the text position.
+ * @property {{ x: number, y: number }} offsetTo { x, y } map coordinates to offset the text to.
  *
- * E.g. { x: 10, y: 20 } will move the callout 10 pixels to the right and 20 pixels down.
+ * E.g. { x: 200, y: 300 } will place the callout at map coordinates (200, 300).
  * @property {number} [leaderGap=5] Distance in pixels between the leader line and the text
  * @property {string} [leaderColor="#121212"] Hex colour of the leader line
  * @property {number} [leaderWidth=1] Stroke width of the leader line
@@ -110,10 +110,8 @@ export class Text {
       "1px 1px 0px #f6f6f6, -1px -1px 0px #f6f6f6, -1px 1px 0px #f6f6f6, 1px -1px #f6f6f6"
     this.radialOffset = options?.radialOffset || 0
 
-    // TODO: offer simple "length" + "angle" instead?
     if (options.callout) {
       this.callout = options.callout
-      this.callout.offsetBy ??= { x: 0, y: 0 }
       this.callout.leaderGap ??= 5
       this.callout.leaderColor ??= "#121212"
       this.callout.leaderWidth ??= 1

--- a/src/lib/components/molecules/canvas-map/map.stories.jsx
+++ b/src/lib/components/molecules/canvas-map/map.stories.jsx
@@ -636,7 +636,7 @@ export const UKMap = {
           content: "Dundee",
           anchor: "left",
           callout: currentZoom < 4 && {
-            offsetBy: { x: 70, y: 20 },
+            offsetTo: { x: -2, y: 56.7 },
             leaderGap: 2,
           },
           icon: {
@@ -662,6 +662,7 @@ export const UKMap = {
         />
         <TextLayer.Component
           features={citiesFeatures}
+          declutter={false}
           style={(feature, currentZoom) => {
             if (feature.properties.name === "Dundee") {
               return dundeeStyle(currentZoom)


### PR DESCRIPTION
This PR changes the `Text` class to offer an `offsetTo` vs `offsetBy`, in its callout options.

This change lets us more precisely and predictably place callout labels. It's now much easier to align multiple callouts: providing the same X or Y coordinate means two or more callouts will be aligned.

This comes at the cost of ease of use: now, consumers will have to know the coordinates of their desired callout placement, which likely means looking at the input geography files.