### PR TITLE
Export saveSVG helper

### DIFF
--- a/src/lib/components/molecules/svg-map/index.jsx
+++ b/src/lib/components/molecules/svg-map/index.jsx
@@ -16,6 +16,7 @@ import { useContainerSize } from "$shared/hooks/useContainerSize"
 
 import styles from "./style.module.css"
 export * as MapLayers from "./layers"
+export { saveSVG } from "./helpers/saveSVG"
 
 export const _Projection = {
   geoAlbersUKComposite: geoAlbersUk(),


### PR DESCRIPTION
Export saveSVG helper so that it can be used by client.