### PR TITLE
Add 'resetVisible' prop to canvas map zoom controls component 

### DIFF
--- a/src/lib/components/molecules/canvas-map/controls/ZoomControl.jsx
+++ b/src/lib/components/molecules/canvas-map/controls/ZoomControl.jsx
@@ -1,7 +1,21 @@
 import { IconPlus, IconMinus, IconReset } from "./icons"
 import styles from "./style.module.css"
 
-export function ZoomControl({ resetEnabled, onZoomIn, onZoomOut, onReset }) {
+/**
+ * @param {Object} props
+ * @param {boolean} props.resetEnabled
+ * @param {boolean} props.resetVisible
+ * @param {(event: MouseEvent) => {}} props.onZoomIn
+ * @param {(event: MouseEvent) => {}} props.onZoomOut
+ * @param {(event: MouseEvent) => {}} props.onReset
+ */
+export function ZoomControl({
+  resetEnabled,
+  resetVisible,
+  onZoomIn,
+  onZoomOut,
+  onReset,
+}) {
   const _onZoomIn = (event) => {
     event.stopPropagation()
     onZoomIn(event)
@@ -27,6 +41,7 @@ export function ZoomControl({ resetEnabled, onZoomIn, onZoomOut, onReset }) {
       </button>
       <button
         className={styles.button}
+        style={{ display: resetVisible ? "block" : "none" }}
         onClick={_onReset}
         disabled={!resetEnabled}
       >


### PR DESCRIPTION
Similar to the 'resetEnabled' prop, this one will let us control whether the reset zoom button is visible, which we may want to use when e.g. zoom level = 1.