### PR TITLE
Add `declutterBoundingBoxPadding` prop to `TextLayer`

### DIFF
--- a/src/lib/components/molecules/canvas-map/lib/layers/TextLayer.js
+++ b/src/lib/components/molecules/canvas-map/lib/layers/TextLayer.js
@@ -19,6 +19,7 @@ export class TextLayer {
     minZoom,
     opacity,
     declutter,
+    declutterBoundingBoxPadding,
     drawCollisionBoxes,
     onClick,
     onHover,
@@ -40,6 +41,7 @@ export class TextLayer {
           minZoom,
           opacity,
           declutter,
+          declutterBoundingBoxPadding,
           drawCollisionBoxes,
           onClick,
           onHover,
@@ -47,7 +49,17 @@ export class TextLayer {
         })
       },
       // eslint-disable-next-line react-hooks/exhaustive-deps
-      [featureCollection, minZoom, opacity, declutter, drawCollisionBoxes],
+      [
+        featureCollection,
+        minZoom,
+        opacity,
+        declutter,
+        declutterBoundingBoxPadding,
+        drawCollisionBoxes,
+        onClick,
+        onHover,
+        restyleOnHover,
+      ],
     )
 
     useEffect(() => {
@@ -86,6 +98,7 @@ export class TextLayer {
    * @param {number} [params.minZoom=0]
    * @param {number} [params.opacity=1]
    * @param {boolean} [params.declutter=true]
+   * @param {number} [params.declutterBoundingBoxPadding=2] Padding added to the bounding box around the TextLayer, that's used to detect collisions for decluttering.
    * @param {boolean} [params.drawCollisionBoxes=false]
    * @param {(feature: import('../Feature').Feature, event: MouseEvent) => void} [params.onClick]
    * @param {(feature: import('../Feature').Feature, event: MouseEvent) => (() => void) | void} [params.onHover]
@@ -103,6 +116,7 @@ export class TextLayer {
     minZoom = 0,
     opacity = 1,
     declutter = true,
+    declutterBoundingBoxPadding = 2,
     drawCollisionBoxes = false,
     onClick,
     onHover,
@@ -139,6 +153,12 @@ export class TextLayer {
      * @public
      */
     this.drawCollisionBoxes = drawCollisionBoxes
+
+    /**
+     * @type {number}
+     * @public
+     */
+    this.declutterBoundingBoxPadding = declutterBoundingBoxPadding
 
     this.onClick = onClick
 

--- a/src/lib/components/molecules/canvas-map/lib/renderers/TextLayerRenderer.js
+++ b/src/lib/components/molecules/canvas-map/lib/renderers/TextLayerRenderer.js
@@ -102,10 +102,15 @@ export class TextLayerRenderer {
         position,
       )
 
-      const bbox = this.getElementBBox(elementDimens, featureStyle.text, {
-        x: relativeX * viewPortSize[0],
-        y: relativeY * viewPortSize[1],
-      })
+      const bbox = this.getElementBBox(
+        elementDimens,
+        featureStyle.text,
+        {
+          x: relativeX * viewPortSize[0],
+          y: relativeY * viewPortSize[1],
+        },
+        this.layer.declutterBoundingBoxPadding,
+      )
 
       // skip item if it collides with existing elements
       if (declutterTree) {
@@ -268,12 +273,12 @@ export class TextLayerRenderer {
    * @param {import("../styles/Text").Text} textStyle
    * @param {{x: number, y: number}} position
    */
-  getElementBBox(dimens, textStyle, position) {
+  getElementBBox(dimens, textStyle, position, padding) {
     const collisionPadding = {
-      top: 2,
-      right: 2,
-      bottom: 2,
-      left: 2,
+      top: padding,
+      right: padding,
+      bottom: padding,
+      left: padding,
     }
 
     const { x: translateX, y: translateY } = textStyle.getTranslation(


### PR DESCRIPTION
This lets us decide how much padding we add to the bounding box that's used to declutter `TextLayer`s. The default value, 2, can be a bit too big when trying to display labels close together.