### PR TITLE
Use pointerover/pointerout vs mouseover/mouseout in TextLayer logic

### DIFF
--- a/src/lib/components/molecules/canvas-map/lib/layers/TextLayer.js
+++ b/src/lib/components/molecules/canvas-map/lib/layers/TextLayer.js
@@ -106,6 +106,9 @@ export class TextLayer {
    * called with the hovered feature, and the mouse event.
    *
    * The callback can optionally return a cleanup function that will be called when the mouse leaves this feature.
+   *
+   * Note that this callback is attached to the "pointerover" and "pointerout" events, so touch
+   * events will not trigger it.
    * @param {boolean} [params.restyleOnHover] If true, the layer will re-render when the mouse hovers over a feature.
    *
    * The provided style function will be called with the `isHovering` parameter set to `true` for the hovered feature.

--- a/src/lib/components/molecules/canvas-map/lib/renderers/TextLayerRenderer.js
+++ b/src/lib/components/molecules/canvas-map/lib/renderers/TextLayerRenderer.js
@@ -373,7 +373,7 @@ export class TextLayerRenderer {
     }
 
     if (this.layer.onHover) {
-      this._element.addEventListener("mouseover", (event) => {
+      this._element.addEventListener("pointerover", (event) => {
         if (!event.target) return
 
         const hoveredFeature = this.layer.source
@@ -385,7 +385,7 @@ export class TextLayerRenderer {
         const onHoverLeave = this.layer.onHover(hoveredFeature, event)
 
         if (onHoverLeave) {
-          this._element.addEventListener("mouseout", onHoverLeave, {
+          this._element.addEventListener("pointerout", onHoverLeave, {
             once: true,
           })
         }
@@ -393,7 +393,7 @@ export class TextLayerRenderer {
     }
 
     if (this.layer.restyleOnHover) {
-      this._element.addEventListener("mouseover", (event) => {
+      this._element.addEventListener("pointerover", (event) => {
         if (!event.target) return
 
         const hoveredFeature = this.layer.source
@@ -407,7 +407,7 @@ export class TextLayerRenderer {
         this.layer.dispatcher.dispatch(MapEvent.CHANGE)
 
         this._element.addEventListener(
-          "mouseout",
+          "pointerout",
           () => {
             this._hoveredFeature = undefined
             this.layer.dispatcher.dispatch(MapEvent.CHANGE)


### PR DESCRIPTION
`mouseover` and `mouseout` are fired by pointing devices (mice) _and_ touch screens. A `mouseover` is fired even a _mouse_ moves, and when a touch screen is _tapped_.

Really, _hovering_ is only something that happens with a mouse.

This changes makes it so that `TextLayer`'s `onHover` and `restyleOnHover` props are only triggered in response to mouse events.