### PR TITLE
Render map to canvas (for PNG export)

### DIFF
--- a/src/lib/components/molecules/canvas-map/lib/Map.js
+++ b/src/lib/components/molecules/canvas-map/lib/Map.js
@@ -315,7 +315,7 @@ export class Map {
       .scaleExtent(this.view.scaleExtent)
       .filter((event) => {
         const filterEvent = (filter) => {
-          this._filterEventCallback(filter)
+          this._filterEventCallback?.(filter)
           return !filter
         }
 

--- a/src/lib/components/molecules/canvas-map/lib/View.js
+++ b/src/lib/components/molecules/canvas-map/lib/View.js
@@ -48,7 +48,8 @@ export class View {
     this._transform = zoomIdentity
     this._padding = padding
     this._viewPortSize = [0, 0]
-    this.pixelRatio = window.devicePixelRatio
+    this.pixelRatio =
+      typeof window !== "undefined" ? window.devicePixelRatio : 1
   }
 
   set viewPortSize(size) {

--- a/src/lib/components/molecules/canvas-map/lib/layers/VectorLayer.js
+++ b/src/lib/components/molecules/canvas-map/lib/layers/VectorLayer.js
@@ -195,8 +195,8 @@ export class VectorLayer {
     return this.source.getFeaturesAtCoordinate(coordinate)
   }
 
-  renderFrame(frameState, targetElement) {
-    return this.renderer.renderFrame(frameState, targetElement)
+  renderFrame(frameState, canvas) {
+    return this.renderer.renderFrame(frameState, canvas)
   }
 }
 

--- a/src/lib/components/molecules/canvas-map/lib/renderers/MapRenderer.js
+++ b/src/lib/components/molecules/canvas-map/lib/renderers/MapRenderer.js
@@ -14,30 +14,31 @@ export class MapRenderer {
   constructor(map) {
     this.map = map
 
-    this._element = document.createElement("div")
-    this._element.className = "gv-layer-container"
-    const style = this._element.style
-    style.position = "absolute"
-    style.width = "100%"
-    style.height = "100%"
-    style.zIndex = "0"
-
     const container = map.viewPort
-    container.insertBefore(this._element, container.firstChild || null)
+    if (container) {
+      this._element = document.createElement("div")
+      this._element.className = "gv-layer-container"
+      const style = this._element.style
+      style.position = "absolute"
+      style.width = "100%"
+      style.height = "100%"
+      style.zIndex = "0"
+
+      container.insertBefore(this._element, container.firstChild || null)
+    }
   }
 
-  renderFrame(frameState) {
+  renderFrame(frameState, canvas) {
     const { zoomLevel, projection, sizeInPixels } = frameState.viewState
 
     const layers = this.map.layers
 
     const mapElements = []
+    const canvasElement = canvas || createCanvas(sizeInPixels)
 
     const visibleLayers = layers.filter((layer) => {
       return zoomLevel > (layer.minZoom || 0)
     })
-
-    const canvasSingleton = makeCanvasSingleton(sizeInPixels)
 
     const renderLayer = (layer, declutterTree) => {
       const viewState = frameState.viewState
@@ -46,18 +47,17 @@ export class MapRenderer {
         viewState.projection = layer.projection
       }
 
-      // Render the layer, providing the canvas singleton in case this layer wants to render our
-      // canvas singleton
-      const newContainer = layer.renderFrame(
+      // Render the layer, providing the main canvas
+      const element = layer.renderFrame(
         { ...frameState, viewState, declutterTree },
-        canvasSingleton,
+        canvasElement,
       )
 
       // If renderFrame created a new element, add it to the list of elements we add to the map
       // container. This is currently only used for the TextLayer, each of which puts its layers in
       // a new div.
-      if (newContainer) {
-        mapElements.push(newContainer)
+      if (element) {
+        mapElements.push(element)
       }
 
       // reset to map projection
@@ -74,71 +74,24 @@ export class MapRenderer {
       }
     }
 
-    if (canvasSingleton.isInitialised()) {
-      // If canvas was used by any layer, add it to the map container, beneath all other elements so
-      // they're not occluded
-      replaceChildren(this._element, [
-        canvasSingleton.getContainer(),
-        ...mapElements,
-      ])
-    } else {
-      replaceChildren(this._element, mapElements)
+    if (this._element) {
+      replaceChildren(this._element, [canvasElement, ...mapElements])
     }
   }
 }
 
 /**
  * @param {[number, number]} sizeInPixels
- * @returns {CanvasSingleton}
  */
-function makeCanvasSingleton(sizeInPixels) {
-  /** @type {HTMLDivElement} */
-  let canvasLayer
-  let canvasContext2d
-
-  return {
-    getContext2d: () => {
-      if (!canvasLayer) {
-        canvasLayer = createCanvasMapLayer(sizeInPixels)
-        canvasContext2d = canvasLayer.firstElementChild.getContext("2d")
-      }
-
-      return canvasContext2d
-    },
-    getContainer: () => {
-      if (!canvasLayer) {
-        canvasLayer = createCanvasMapLayer(sizeInPixels)
-        canvasContext2d = canvasLayer.firstElementChild.getContext("2d")
-      }
-
-      return canvasLayer
-    },
-    isInitialised: () => !!canvasLayer,
-  }
-}
-
-/**
- * @param {[number, number]} sizeInPixels
- */
-function createCanvasMapLayer(sizeInPixels) {
-  const container = document.createElement("div")
-  container.className = "gv-map-layer"
-
-  let style = container.style
-  style.position = "absolute"
-  style.width = "100%"
-  style.height = "100%"
-
+function createCanvas(sizeInPixels) {
   const canvas = document.createElement("canvas")
-  style = canvas.style
-  style.position = "absolute"
-  style.width = "100%"
-  style.height = "100%"
+  canvas.className = "gv-map-layer"
+  canvas.style.position = "absolute"
+  canvas.style.width = "100%"
+  canvas.style.height = "100%"
 
   canvas.width = sizeInPixels[0]
   canvas.height = sizeInPixels[1]
 
-  container.appendChild(canvas)
-
-  return container
+  return canvas
 }

--- a/src/lib/components/molecules/canvas-map/lib/renderers/TextLayerRenderer.js
+++ b/src/lib/components/molecules/canvas-map/lib/renderers/TextLayerRenderer.js
@@ -33,9 +33,9 @@ export class TextLayerRenderer {
   }
 
   /**
-   * @param {import("./MapRenderer").CanvasSingleton} canvasSingleton
+   * @param {HTMLCanvasElement} canvas
    */
-  renderFrame(frameState, canvasSingleton) {
+  renderFrame(frameState, canvas) {
     if (this.layer.opacity === 0) return null
 
     const { declutterTree } = frameState
@@ -121,7 +121,7 @@ export class TextLayerRenderer {
       const icon = featureStyle?.text?.icon
 
       if (callout || icon) {
-        canvasCtx ??= canvasSingleton.getContext2d()
+        canvasCtx ??= canvas.getContext("2d")
       }
 
       if (callout) {
@@ -183,6 +183,12 @@ export class TextLayerRenderer {
     return this._element
   }
 
+  /**
+   * Function that gets or creates a text element.
+   *
+   * @param {String} id
+   * @returns {HTMLDivElement}
+   */
   getTextElementWithID(id) {
     const elementId = `text-feature-${id}`
     let textElement = this._element.querySelector(`#${elementId}`)
@@ -195,10 +201,13 @@ export class TextLayerRenderer {
     }
 
     if (this._mouseInteractionsEnabled) {
+      // @ts-ignore
       textElement.style.pointerEvents = "auto"
+      // @ts-ignore
       textElement.style.cursor = "pointer"
     }
 
+    // @ts-ignore
     return textElement
   }
 

--- a/src/lib/components/molecules/canvas-map/lib/renderers/VectorLayerRenderer.js
+++ b/src/lib/components/molecules/canvas-map/lib/renderers/VectorLayerRenderer.js
@@ -14,14 +14,14 @@ export class VectorLayerRenderer {
   }
 
   /**
-   * @param {import("./MapRenderer").CanvasSingleton} canvasSingleton
+   * @param {HTMLCanvasElement} canvas
    */
-  renderFrame(frameState, canvasSingleton) {
-    if (this.layer.opacity === 0) return null
+  renderFrame(frameState, canvas) {
+    if (this.layer.opacity === 0) return canvas
 
     const { projection, visibleExtent, transform } = frameState.viewState
 
-    const context = canvasSingleton.getContext2d()
+    const context = canvas.getContext("2d")
 
     context.save()
 

--- a/src/lib/components/molecules/option-picker/index.jsx
+++ b/src/lib/components/molecules/option-picker/index.jsx
@@ -5,11 +5,18 @@ import defaultStyles from "./style.module.css"
 /** @typedef { ("vertical" | "horizontal") } OptionLayoutDirection */
 
 /**
+ * @typedef { Object } Option
+ * @prop { String } title
+ * @prop { String } [description]
+ * @prop { String | import("preact").JSX.Element } icon
+ */
+
+/**
  * OptionPicker component
  *
  * @param {Object} props
  * @param {string} props.title
- * @param {Array<{ title: string, description: string, icon: string | JSX.Element }>} props.options
+ * @param {Option[]} props.options
  * @param {OptionLayoutDirection} [props.layoutDirection="horizontal"]
  * @param {number} [props.initialSelectedIndex=0]
  * @param {(index: number, option: Object) => void} [props.onSelect]


### PR DESCRIPTION
Adds `renderToCanvas` method to `Map.js`, to enable rendering maps to static image files.