### PR TITLE
Results summary: add line clamping 

### DIFF
--- a/src/lib/components/molecules/result-summary/index.jsx
+++ b/src/lib/components/molecules/result-summary/index.jsx
@@ -11,6 +11,7 @@ export function ResultSummary({
   timestamp,
   onClick,
   isSlim = false,
+  lineClamp = false,
   styles,
 }) {
   styles = mergeStyles({ ...defaultStyles }, styles)
@@ -23,27 +24,30 @@ export function ResultSummary({
         className={`${styles.container} ${styles.containerSlim}`}
         onClick={onClick}
       >
-        {hasChanged ? (
-          <GradientIcon
-            previous={previous}
-            next={next}
-            styles={{
-              previous: styles.previous,
-              next: styles.next,
-            }}
-          />
-        ) : (
-          <CircleIcon styles={{ circle: `fill-color--${next}` }} />
-        )}
-        <p className={styles.titleSlim}>{title} </p>
-        <RelativeTimeSentence timeStamp={timestamp} />
+        <p className={`${styles.titleSlim} ${lineClamp && styles.lineClamp}`}>
+          {hasChanged ? (
+            <GradientIcon
+              previous={previous}
+              next={next}
+              styles={{
+                previous: styles.previous,
+                next: styles.next,
+              }}
+            />
+          ) : (
+            <CircleIcon styles={{ circle: `fill-color--${next}` }} />
+          )}{" "}
+          {title} <RelativeTimeSentence timeStamp={timestamp} />
+        </p>
       </div>
     )
   } else {
     return (
       <div className={styles.container}>
         <ControlChange previous={previous} next={next} text={title} />
-        <p className={styles.paragraph}>{text}</p>
+        <p className={`${styles.paragraph} ${lineClamp && styles.lineClamp}`}>
+          {text}
+        </p>
         <RelativeTimeSentence timeStamp={timestamp} />
       </div>
     )

--- a/src/lib/components/molecules/result-summary/result-summary.stories.jsx
+++ b/src/lib/components/molecules/result-summary/result-summary.stories.jsx
@@ -27,6 +27,7 @@ export const Default = {
     title: "Con gain from Lab",
     text: "Camberwell and Peckham",
     timestamp,
+    lineClamp: false,
   },
 }
 
@@ -37,5 +38,17 @@ export const Slim = {
     title: "Harris flips Arizona, a key swing state",
     timestamp,
     isSlim: true,
+  },
+}
+
+export const SlimPlusLineClamping = {
+  args: {
+    previous: "gop",
+    next: "dem",
+    title:
+      "Harris flips Arizona, a key swing state and lots of long text which should be cut off after 2 lines",
+    timestamp,
+    isSlim: true,
+    lineClamp: true,
   },
 }

--- a/src/lib/components/molecules/result-summary/style.module.css
+++ b/src/lib/components/molecules/result-summary/style.module.css
@@ -24,6 +24,19 @@
   margin-left: var(--space-1) !important;
 }
 
+.lineClamp {
+  /* restrict lines of text to 2, or else add ellipses */
+  display: -webkit-inline-box !important;
+  display: -moz-inline-box !important;
+  -webkit-box-orient: vertical;
+  -moz-box-orient: vertical;
+  line-clamp: 2;
+  -webkit-line-clamp: 2;
+  -moz-line-clamp: 2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .dateStampLinePosition {
   display: block;
 }


### PR DESCRIPTION
This adds a property to the Results Summary component which cuts off the text with an ellipsis after two lines. 

- the property is defaulted to false 
- the number of lines could be overridden in CSS if a different number of lines is required 

Envisaged that this will mainly work with the slim version, but it also clips the default version as well. 

![Screenshot 2024-10-21 at 13 16 16](https://github.com/user-attachments/assets/d4b33b2f-ea79-4351-bfc9-82bb367e0b48)

And pulled into US repo: 
![Screenshot 2024-10-21 at 13 05 51](https://github.com/user-attachments/assets/3f06e5c3-64ec-4ea0-8d4e-e2fd9502a48d)

