### PR TITLE
Don't draw features with `pointRadius: 0`

### DIFF
--- a/src/lib/components/molecules/canvas-map/lib/renderers/FeatureRenderer.js
+++ b/src/lib/components/molecules/canvas-map/lib/renderers/FeatureRenderer.js
@@ -27,6 +27,10 @@ export class FeatureRenderer {
 
     const { stroke, fill, pointRadius } = this.style
 
+    if (typeof pointRadius === "number" && pointRadius <= 0) {
+      return
+    }
+
     const geometries = feature.getProjectedGeometries(projection)
 
     if (frameState.debug) {


### PR DESCRIPTION
It seems d3-geo will default to a fixed size when we ask it to draw points with `pointRadius: 0`, leading to situations like this: all of these points are meant to be 0 radius!

<img width="500" alt="image" src="https://github.com/user-attachments/assets/186b0e59-b0da-4d20-820a-9d5d654de764">

This PR simply skips drawing altogether for features whose `pointRadius` is 0.
