### PR TITLE
Fix bug in VectorLayerRenderer

### DIFF
--- a/src/lib/components/molecules/canvas-map/lib/Map.js
+++ b/src/lib/components/molecules/canvas-map/lib/Map.js
@@ -262,8 +262,8 @@ export class Map {
     this._requestRender()
   }
 
-  async transition(options = { duration: 500 }, callback) {
-    const ease = options.ease || ((t) => t)
+  async transition(options = { duration: 500, ease: (t) => t }, callback) {
+    const ease = options.ease
     return new Promise((resolve) => {
       this._isTransitioning = true
       this.dispatcher.dispatch(MapEvent.TRANSITION_START)

--- a/src/lib/components/molecules/canvas-map/lib/layers/TextLayer.js
+++ b/src/lib/components/molecules/canvas-map/lib/layers/TextLayer.js
@@ -94,7 +94,7 @@ export class TextLayer {
    * @constructor
    * @param {Object} params
    * @param {VectorSource} params.source
-   * @param {Style | (() => Style)} [params.style=undefined]
+   * @param {Style | ((feature: import('../Feature').Feature, zoom: number, isHovering: boolean) => Style)} [params.style=undefined]
    * @param {number} [params.minZoom=0]
    * @param {number} [params.opacity=1]
    * @param {boolean} [params.declutter=true]

--- a/src/lib/components/molecules/canvas-map/lib/renderers/VectorLayerRenderer.js
+++ b/src/lib/components/molecules/canvas-map/lib/renderers/VectorLayerRenderer.js
@@ -17,7 +17,7 @@ export class VectorLayerRenderer {
    * @param {HTMLCanvasElement} canvas
    */
   renderFrame(frameState, canvas) {
-    if (this.layer.opacity === 0) return canvas
+    if (this.layer.opacity === 0) return null
 
     const { projection, visibleExtent, transform } = frameState.viewState
 

--- a/src/lib/components/molecules/canvas-map/lib/util/toRgba.js
+++ b/src/lib/components/molecules/canvas-map/lib/util/toRgba.js
@@ -33,5 +33,5 @@ export function toRgba(color, opacity = 1) {
     return `rgba(${r}, ${g}, ${b}, ${a})`
   }
 
-  throw new Error("Unsupported color format")
+  throw new Error(`Unsupported color format: ${color}`)
 }


### PR DESCRIPTION
Fixes bug in VectorLayerRenderer, where the canvas is returned as a new element to be added to the map if `opacity===0`. `renderFrame` should return `null` unless a new DOM element has been created.

Also includes small stylistic tweaks and improvement of JSDoc types.