### PR TITLE
Re-use canvas between renders

### DIFF
--- a/src/lib/components/molecules/canvas-map/lib/renderers/MapRenderer.js
+++ b/src/lib/components/molecules/canvas-map/lib/renderers/MapRenderer.js
@@ -15,6 +15,7 @@ export class MapRenderer {
     this.map = map
 
     const container = map.viewPort
+
     if (container) {
       this._element = document.createElement("div")
       this._element.className = "gv-layer-container"
@@ -34,7 +35,21 @@ export class MapRenderer {
     const layers = this.map.layers
 
     const mapElements = []
-    const canvasElement = canvas || createCanvas(sizeInPixels)
+
+    let canvasElement
+
+    if (canvas) {
+      canvasElement = canvas
+    } else if (this._canvas) {
+      canvasElement = this._canvas
+
+      // Setting the height and width of the canvas also clears it
+      canvasElement.width = sizeInPixels[0]
+      canvasElement.height = sizeInPixels[1]
+    } else {
+      canvasElement = createCanvas(sizeInPixels)
+      this._canvas = canvasElement
+    }
 
     const visibleLayers = layers.filter((layer) => {
       return zoomLevel > (layer.minZoom || 0)


### PR DESCRIPTION
This change replicates the behaviour we had prior to f2030d2, before I removed it!

It fixes the glitchy zooming and panning issues we've been noticing in the US election pages recently.

Without this fix, we're creating a new canvas element whenever anything in the map changes, including changing zoom level or pan position. Creating a new canvas for every frame means we're destroying and re-attaching the mouse/touchmove listeners added by d3-zoom to control zooming and panning, leading to the stuttery behaviour we've been noticing.

Using a single canvas element, as we used to, solves this problem.

| Before | After |
| - | - |
| <video src="https://github.com/user-attachments/assets/3ea45ae2-820a-4526-9be3-1de960d867b7"> | <video src="https://github.com/user-attachments/assets/b4c44eea-1e53-4845-922d-b2bb2a50f1cc"> |
| <video src="https://github.com/user-attachments/assets/24beae42-7e7f-429f-9bd1-ae9ebddb4c0a"> | <video src="https://github.com/user-attachments/assets/faf028e1-fd9b-4bec-96da-e3a98e1e10bb"> |











