### PR TITLE
Update tooltip visibility on scroll

### DIFF
--- a/src/lib/components/molecules/tooltip/tooltip.stories.jsx
+++ b/src/lib/components/molecules/tooltip/tooltip.stories.jsx
@@ -59,7 +59,7 @@ function TooltipForButton() {
           flexDirection: "row",
         }}
       >
-        <p style={{ pointerEvents: "none" }}>
+        <p>
           Tooltip shows when gray area receives touch or mouseover event, but is
           anchored to info button.
         </p>

--- a/src/lib/components/molecules/tooltip/tooltip.stories.jsx
+++ b/src/lib/components/molecules/tooltip/tooltip.stories.jsx
@@ -59,7 +59,7 @@ function TooltipForButton() {
           flexDirection: "row",
         }}
       >
-        <p>
+        <p style={{ pointerEvents: "none" }}>
           Tooltip shows when gray area receives touch or mouseover event, but is
           anchored to info button.
         </p>

--- a/src/lib/shared/hooks/useTouchOrHover.js
+++ b/src/lib/shared/hooks/useTouchOrHover.js
@@ -104,18 +104,16 @@ export function useTouchOrHover() {
     }
 
     const pageScroll = () => {
-      const elementFromPoint = document.elementFromPoint(
+      const elementsFromPoint = document.elementsFromPoint(
         cursorPosition.x,
         cursorPosition.y,
       )
-      if (elementFromPoint !== element) {
+      if (!elementsFromPoint.includes(element)) {
         setIsActive(false)
       } else {
         setIsActive(true)
       }
     }
-
-    const scrollEnded = () => {}
 
     element.addEventListener("touchstart", touchStarted)
     element.addEventListener("touchmove", touchMoved)
@@ -127,7 +125,6 @@ export function useTouchOrHover() {
     element.addEventListener("mouseout", mouseOut)
 
     window.addEventListener("scroll", pageScroll)
-    window.addEventListener("scrollend", scrollEnded)
 
     return () => {
       element.removeEventListener("touchstart", touchStarted)
@@ -140,7 +137,6 @@ export function useTouchOrHover() {
       element.removeEventListener("mouseout", mouseOut)
 
       window.removeEventListener("scroll", pageScroll)
-      window.removeEventListener("scrollend", scrollEnded)
     }
   }, [cursorPosition])
 

--- a/src/lib/shared/hooks/useTouchOrHover.js
+++ b/src/lib/shared/hooks/useTouchOrHover.js
@@ -8,6 +8,7 @@ export function useTouchOrHover() {
   const [position, setPosition] = useState()
   const [isActive, setIsActive] = useState(false)
   const [touchRect, setTouchRect] = useState()
+  const [cursorPosition, setCursorPosition] = useState({ x: 0, y: 0 })
 
   useEffect(() => {
     const element = ref.current
@@ -93,6 +94,7 @@ export function useTouchOrHover() {
 
       setActiveEvent(event)
       setPosition({ x, y })
+      setCursorPosition({ x: clientX, y: clientY })
     }
 
     const mouseOut = () => {
@@ -100,6 +102,20 @@ export function useTouchOrHover() {
       setActiveEvent(null)
       setIsActive(false)
     }
+
+    const pageScroll = () => {
+      const elementFromPoint = document.elementFromPoint(
+        cursorPosition.x,
+        cursorPosition.y,
+      )
+      if (elementFromPoint !== element) {
+        setIsActive(false)
+      } else {
+        setIsActive(true)
+      }
+    }
+
+    const scrollEnded = () => {}
 
     element.addEventListener("touchstart", touchStarted)
     element.addEventListener("touchmove", touchMoved)
@@ -110,6 +126,9 @@ export function useTouchOrHover() {
     element.addEventListener("mousemove", mouseMoved)
     element.addEventListener("mouseout", mouseOut)
 
+    window.addEventListener("scroll", pageScroll)
+    window.addEventListener("scrollend", scrollEnded)
+
     return () => {
       element.removeEventListener("touchstart", touchStarted)
       element.removeEventListener("touchmove", touchMoved)
@@ -119,8 +138,11 @@ export function useTouchOrHover() {
       element.removeEventListener("mouseover", touchStarted)
       element.removeEventListener("mousemove", mouseMoved)
       element.removeEventListener("mouseout", mouseOut)
+
+      window.removeEventListener("scroll", pageScroll)
+      window.removeEventListener("scrollend", scrollEnded)
     }
-  }, [])
+  }, [cursorPosition])
 
   return {
     touchOrHoverRef: ref,


### PR DESCRIPTION
## What does this change?

This adjusts `useTouchOrHover.js` to fix a bug where the tooltip stays visible even after users scroll away from it (see [this Trello card](https://trello.com/c/jNDLLvgs/732-tooltips-arent-closing-when-you-hover-over-them-and-then-scroll-down-the-page-desktop-only) for more context). This is only an issue on desktop as mouse move events don't fire when a scroll is happening.

The fix adds a state to monitor the position of the cursor and checks if it's over the tooltip's element even during scroll using [elementsFromPoint()](https://developer.mozilla.org/en-US/docs/Web/API/Document/elementsFromPoint). (Note that this is used instead of [elementFromPoint()](https://developer.mozilla.org/en-US/docs/Web/API/Document/elementFromPoint) because the latter falls over when it meets elements _inside_ the hover element.

![chrome-capture-2024-9-30](https://github.com/user-attachments/assets/20429c4f-dd38-419c-86fe-a3be19c5ccca)

The funky interplay between mouse movement and scroll events seems to make this necessary as mouse events don't fire until a scroll is over. Funnily enough this seems to work because on scroll technically the cursor isn't moving anywhere - the page is!

## How to test

Run locally and mess around with the 'Button Touch Or Hover' preview of the Tooltip molecule.

## How can we measure success?

Bug gone. No new bugs introduced.

## Have we considered potential risks?

Finicky nature of this means there could still be some loophole where the tooltip doesn't appear/disappear as expected. A nice built-in fallback here is that the cursor position updates when the mouse moves, so even in a worst case scenario things could only get so out of sync before resetting.

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
