### PR TITLE
Null check layerExtent in map's findLayers

### DIFF
--- a/src/lib/components/molecules/canvas-map/lib/Map.js
+++ b/src/lib/components/molecules/canvas-map/lib/Map.js
@@ -245,6 +245,7 @@ export class Map {
     for (const layer of this.layers) {
       const layerExtent = layer.getExtent()
       if (
+        layerExtent &&
         layer.hitDetectionEnabled &&
         containsCoordinate(layerExtent, mapCoordinate)
       ) {


### PR DESCRIPTION
In some niche cases where a VectorLayer is rendered without any features, `layerExtent` is null here.