### PR TITLE
Fix canvas map "collaborativeGesturesEnabled" check, one-touch panning

### DIFF
--- a/src/lib/components/molecules/canvas-map/lib/Map.js
+++ b/src/lib/components/molecules/canvas-map/lib/Map.js
@@ -329,7 +329,7 @@ export class Map {
           return filterEvent(true)
         }
 
-        if ("targetTouches" in event && this.collaborativeGesturesEnabled) {
+        if ("targetTouches" in event && this.collaborativeGesturesEnabled()) {
           if (event.targetTouches.length < 2) {
             // ignore single touches
             return false


### PR DESCRIPTION
This fix ensures that the Map component's `inModalState` prop works correctly, which is designed to allow the map to be panned with a single finger, instead of two.

Currently, the line of code that this PR touches means that one-finger gestures are _always_ filtered, regardless of the value of the `_collaborativeGesturesEnabled` flag.

This PR makes sure that we _call_ the function that returns this value, rather than checking a reference to the function itself, which will always be truthy!