### PR TITLE
Center align refresh indicator circle icon

### DIFF
--- a/src/lib/components/molecules/refresh-indicator/style.module.scss
+++ b/src/lib/components/molecules/refresh-indicator/style.module.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: row;
   column-gap: var(--space-0);
-  align-items: stretch;
+  align-items: center;
   flex-wrap: wrap;
 }
 


### PR DESCRIPTION
Using align-items: stretch sees the text and circle icon offset in some layout situations. Using center means they'll always be aligned.