### PR TITLE
Hide 'Code' tab

### DIFF
--- a/.github/workflows/pr-npm-comment.yml
+++ b/.github/workflows/pr-npm-comment.yml
@@ -1,3 +1,6 @@
+# Currently disabled, we'll need this to build the project and upload the result as an 'artifact',
+# which we can link to via GitHub's REST API
+
 name: NPM install PR comment
 
 on:

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -30,14 +30,6 @@ const config = {
     },
     "@storybook/addon-interactions",
     "storybook-dark-mode",
-    {
-      name: "@storybook/addon-storysource",
-      options: {
-        sourceLoaderOptions: {
-          injectStoryParameters: false,
-        },
-      },
-    },
   ],
   framework: {
     name: "@storybook/preact-vite",


### PR DESCRIPTION
This tab only shows the story args object for some reason, not a full component snippet as advertised. While this info is perhaps useful, it's mainly confusing, especially for those who don't know the internals of our Storybook.

For this reason, it's better to hide this tab, for now.