### PR TITLE
Add initial Ticker v2 component; allow no "header" in PageSection

### DIFF
--- a/src/lib/components/molecules/page-section/index.jsx
+++ b/src/lib/components/molecules/page-section/index.jsx
@@ -27,7 +27,10 @@ export const PageSection = forwardRef(
 
     useLayoutEffect(() => {
       const headerElement = headerRef.current
-      setMinHeight(headerElement.offsetHeight)
+
+      if (headerElement) {
+        setMinHeight(headerElement.offsetHeight)
+      }
     }, [children])
 
     return (
@@ -38,12 +41,14 @@ export const PageSection = forwardRef(
         style={{ "--background-color": backgroundColor, minHeight }}
       >
         {borderTop && <div className={styles.borderTop} />}
-        <div
-          className={[styles.header, styles[layout]].join(" ")}
-          ref={headerRef}
-        >
-          {children.header}
-        </div>
+        {children.header && (
+          <div
+            className={[styles.header, styles[layout]].join(" ")}
+            ref={headerRef}
+          >
+            {children.header}
+          </div>
+        )}
         <div className={[styles.content, styles[layout]].join(" ")}>
           {children.content}
         </div>

--- a/src/lib/components/molecules/page-section/style.module.scss
+++ b/src/lib/components/molecules/page-section/style.module.scss
@@ -172,6 +172,10 @@
   }
 }
 
+:not(.header) + .content {
+  padding-top: var(--space-2);
+}
+
 .content.fullWidth {
   padding-top: 0;
 }

--- a/src/lib/components/organisms/index.js
+++ b/src/lib/components/organisms/index.js
@@ -1,2 +1,3 @@
 export * from "./coalitions-tracker"
 export * from "./ticker"
+export { Ticker as Ticker2 } from "./ticker-v2"

--- a/src/lib/components/organisms/ticker-v2/Gradient.jsx
+++ b/src/lib/components/organisms/ticker-v2/Gradient.jsx
@@ -1,0 +1,41 @@
+import styles from "./style.module.scss"
+
+export function Gradient({ position = "left" }) {
+  return (
+    <svg
+      className={styles.gradient}
+      data-position={position}
+      width="100%"
+      height="100%"
+      viewBox="0 0 10 10"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      preserveAspectRatio="none"
+    >
+      <g>
+        <rect width="100%" height="100%" fill="url(#paint0_linear_3798_6653)" />
+      </g>
+      <defs>
+        <linearGradient
+          id="paint0_linear_3798_6653"
+          x1="0%"
+          y1="0%"
+          x2="100%"
+          y2="0%"
+        >
+          {position === "left" ? (
+            <>
+              <stop className={styles.lastStop} offset="1" />
+              <stop className={styles.firstStop} />
+            </>
+          ) : (
+            <>
+              <stop className={styles.firstStop} />
+              <stop className={styles.lastStop} offset="1" />
+            </>
+          )}
+        </linearGradient>
+      </defs>
+    </svg>
+  )
+}

--- a/src/lib/components/organisms/ticker-v2/index.jsx
+++ b/src/lib/components/organisms/ticker-v2/index.jsx
@@ -1,0 +1,116 @@
+import { toChildArray } from "preact"
+import { mergeStyles } from "$styles/helpers/mergeStyles"
+import defaultStyles from "./style.module.scss"
+import { Gradient } from "./Gradient.jsx"
+import { ArrowButton } from "$particles"
+import { useRef, useState, useEffect } from "preact/hooks"
+
+export function Ticker({ buttonScrollDistance = 250, styles, children }) {
+  styles = mergeStyles({ ...defaultStyles }, styles)
+
+  const [isScrolledToStart, setIsScrolledToStart] = useState(true)
+  const [isScrolledToEnd, setIsScrolledToEnd] = useState(false)
+  const [isOverflow, setIsOverflow] = useState(false)
+
+  const childArray = toChildArray(children)
+  const scrollContainerRef = useRef(null)
+
+  function scrubLeft() {
+    const scrollContainer = scrollContainerRef.current
+    if (!scrollContainer) return
+
+    let newScrollLeft = scrollContainer.scrollLeft - buttonScrollDistance
+
+    if (newScrollLeft < 100) {
+      newScrollLeft = 0
+    }
+
+    scrollContainer.scrollTo({
+      left: newScrollLeft,
+      behavior: "smooth",
+    })
+  }
+
+  function scrubRight() {
+    const scrollContainer = scrollContainerRef.current
+    if (!scrollContainer) return
+
+    let scrollSpace = scrollContainer.scrollWidth - scrollContainer.clientWidth
+    let newScrollLeft = scrollContainer.scrollLeft + buttonScrollDistance
+
+    if (newScrollLeft > scrollSpace - 100) {
+      // Plus one here to account for any fractional numbers
+      newScrollLeft = scrollSpace + 1
+    }
+
+    scrollContainer.scrollTo({
+      left: newScrollLeft,
+      behavior: "smooth",
+    })
+  }
+
+  useEffect(() => {
+    const scrollContainer = scrollContainerRef.current
+    if (!scrollContainer) return
+
+    let scrollDebounceTimeout
+
+    const handleScroll = () => {
+      clearTimeout(scrollDebounceTimeout)
+
+      scrollDebounceTimeout = setTimeout(() => {
+        const currentScroll = scrollContainer.scrollLeft
+        const scrollSpace =
+          scrollContainer.scrollWidth - scrollContainer.clientWidth - 4
+
+        setIsScrolledToEnd(currentScroll > scrollSpace)
+        setIsScrolledToStart(currentScroll === 0)
+      }, 20)
+    }
+
+    scrollContainer.addEventListener("scroll", handleScroll)
+
+    return () => {
+      clearTimeout(scrollDebounceTimeout)
+      scrollContainer.removeEventListener("scroll", handleScroll)
+    }
+  }, [])
+
+  useEffect(() => {
+    const scrollContainer = scrollContainerRef.current
+    if (!scrollContainer) return
+
+    if (scrollContainer.scrollWidth > scrollContainer.clientWidth) {
+      setIsOverflow(true)
+    }
+  }, [children])
+
+  return (
+    <div className={styles.ticker}>
+      <div ref={scrollContainerRef} className={styles.scrollContainer}>
+        {childArray.map((child, index) => (
+          <div className={styles.tickerItem} key={child.props?.id ?? index}>
+            {child}
+          </div>
+        ))}
+      </div>
+
+      <div
+        className={`${styles.scrubControls} ${isOverflow ? styles.showControls : ""}`}
+      >
+        <Gradient position="right" />
+        <ArrowButton
+          styles={{ button: styles.arrowButton }}
+          onClick={scrubRight}
+          disabled={isScrolledToEnd}
+        />
+        <ArrowButton
+          styles={{ button: styles.arrowButton }}
+          direction="left"
+          onClick={scrubLeft}
+          disabled={isScrolledToStart}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/lib/components/organisms/ticker-v2/stories.module.scss
+++ b/src/lib/components/organisms/ticker-v2/stories.module.scss
@@ -1,0 +1,58 @@
+.storyContainer {
+  background-color: var(--tertiary-bg-color);
+}
+
+h2 {
+  color: var(--primary-text-color);
+  font-family: var(--text-headline);
+  font-size: var(--headline-xxsmall);
+  line-height: var(--headline-line-height);
+  font-weight: 700;
+}
+
+.content {
+  color: var(--primary-text-color);
+  font-family: var(--text-body);
+  font-size: var(--body-medium);
+  height: 200px;
+}
+
+.grid {
+  display: grid;
+
+  grid-template-columns: 100%;
+  grid-column-gap: 0px;
+  grid-template-areas: "body";
+
+  min-height: 150vh;
+
+  @include mq($from: desktop) {
+    grid-column-gap: 20px;
+    grid-template-areas: "body";
+  }
+
+  @include mq($from: leftCol) {
+    grid-template-columns: 140px 1px calc(100% - 161px);
+    grid-column-gap: 10px;
+    grid-template-areas: ".          border-body       body";
+  }
+
+  @include mq($from: wide) {
+    grid-template-columns: 219px 1px calc(100% - 240px);
+  }
+}
+
+.body {
+  grid-area: body;
+  padding: 20px 0;
+}
+
+.border {
+  display: none;
+
+  @include mq($from: leftCol) {
+    display: block;
+    grid-area: border-body;
+    border-left: 1px solid #dcdcdc;
+  }
+}

--- a/src/lib/components/organisms/ticker-v2/style.module.scss
+++ b/src/lib/components/organisms/ticker-v2/style.module.scss
@@ -1,0 +1,85 @@
+.ticker {
+  width: 100%;
+  position: relative;
+}
+
+.scrollContainer {
+  position: relative;
+  padding: 0;
+  cursor: default;
+
+  display: flex;
+  flex-direction: row;
+  gap: var(--space-2);
+
+  overflow-x: scroll;
+
+  @include mq($until: mobileLandscape) {
+    /* Make room for bottom scroll bar */
+    padding-bottom: 8px;
+  }
+
+  @include mq($from: mobileLandscape) {
+    /* Make room for the scrub controls */
+    padding-right: 36px;
+
+    &::-webkit-scrollbar {
+      display: none; /* for Chrome, Safari, and Opera */
+    }
+  }
+}
+
+.tickerItem {
+  flex-shrink: 0;
+}
+
+.scrubControls {
+  position: absolute;
+  right: 0;
+  top: 0;
+
+  height: 100%;
+
+  flex-direction: column;
+  justify-content: center;
+
+  display: none;
+}
+
+.scrubControls.showControls {
+  display: flex;
+
+  @include mq($until: mobileLandscape) {
+    display: none;
+  }
+}
+
+.arrowButton {
+  z-index: 1;
+}
+
+.gradient {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+
+  width: 40px;
+}
+
+.gradient[data-position="left"] {
+  left: 0;
+}
+
+.gradient[data-position="right"] {
+  right: 0;
+}
+
+.firstStop {
+  stop-color: var(--tertiary-bg-color);
+  stop-opacity: 0;
+}
+
+.lastStop {
+  stop-color: var(--tertiary-bg-color);
+  stop-opacity: 1;
+}

--- a/src/lib/components/organisms/ticker-v2/ticker.stories.jsx
+++ b/src/lib/components/organisms/ticker-v2/ticker.stories.jsx
@@ -1,0 +1,128 @@
+import { Ticker } from "."
+import { Container } from "$particles"
+import { PageSection, ResultSummary } from "$molecules"
+import { useRef } from "preact/hooks"
+import styles from "./stories.module.scss"
+
+const now = Date.now()
+const minuteInMilliseconds = 60000
+
+const meta = {
+  title: "Organisms/Ticker2",
+  component: Ticker,
+  parameters: {
+    layout: "fullscreen",
+    viewport: {
+      defaultViewport: "mobile",
+    },
+  },
+  decorators: [
+    (Story) => (
+      <StoryContainer>
+        <Story />
+      </StoryContainer>
+    ),
+  ],
+  render: ({ items, ...args }) => {
+    return (
+      <Ticker {...args}>
+        {items.map((d, index) => (
+          <ResultSummary
+            {...d}
+            timestamp={now - minuteInMilliseconds * index}
+            key={index}
+          />
+        ))}
+      </Ticker>
+    )
+  },
+}
+
+export default meta
+
+const items = [
+  {
+    previous: "lab",
+    next: "con",
+    title: "Con gain from Lab",
+    text: "Camberwell and Peckham",
+  },
+  {
+    previous: "con",
+    next: "lab",
+    title: "Lab gain from Con",
+    text: "Chingford",
+  },
+  {
+    previous: "lab",
+    next: "con",
+    title: "Con gain from Lab",
+    text: "Camberwell and Peckham",
+  },
+]
+
+export const ThreeResults = {
+  args: {
+    items,
+  },
+}
+
+export const SixResults = {
+  args: {
+    items: [...items, ...items],
+  },
+}
+
+export const LongTitleAndText = {
+  args: {
+    items: [
+      {
+        previous: "con",
+        next: "lab",
+        title: "Con’s Iain Duncan Smith loses to Lab",
+        text: "Cumbernauld, Kilsyth and Kirkintilloch East",
+      },
+      {
+        previous: "lab",
+        next: "con",
+        title: "Con gain from Lab",
+        text: "Camberwell and Peckham",
+      },
+      {
+        previous: "con",
+        next: "lab",
+        title: "Con’s Jane Doe loses to Lab",
+        text: "Tottenham",
+      },
+      ...items,
+    ],
+  },
+}
+
+function StoryContainer({ children }) {
+  const tickerSectionRef = useRef()
+
+  return (
+    <div className={styles.storyContainer}>
+      <Container sideBorders={true}>
+        <div className={styles.grid}>
+          <div className={styles.border} />
+          <div className={styles.body}>
+            <PageSection ref={tickerSectionRef}>
+              {{
+                header: <h2>Latest seats declared</h2>,
+                content: children,
+              }}
+            </PageSection>
+            <PageSection borderTop={true}>
+              {{
+                header: <h2>Next section</h2>,
+                content: <p className={styles.content}>Section content</p>,
+              }}
+            </PageSection>
+          </div>
+        </div>
+      </Container>
+    </div>
+  )
+}


### PR DESCRIPTION
This new Ticker2 component aims to simplify the original ticker component by relying on more native functionality.

It uses `scrollTo` instead of `translateX`, and `display: flex` to lay out the elements. It also allows items to be variable width.